### PR TITLE
Bugfix/114 ruin criticals pruning

### DIFF
--- a/core/src/main/java/com/github/rumsfield/konquest/KonquestPlugin.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/KonquestPlugin.java
@@ -67,7 +67,7 @@ public class KonquestPlugin extends JavaPlugin {
 			konquest.getKingdomManager().saveKingdoms();
 			konquest.getCampManager().saveCamps();
 			konquest.getRuinManager().saveRuins();
-			konquest.getRuinManager().regenAllCriticalBlocks();
+			konquest.getRuinManager().regenAllRuins();
 			konquest.getRuinManager().removeAllGolems();
 			konquest.getKingdomManager().removeAllRabbits();
 			konquest.getConfigManager().saveConfigs();

--- a/core/src/main/java/com/github/rumsfield/konquest/listener/WorldListener.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/listener/WorldListener.java
@@ -10,8 +10,11 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.world.ChunkLoadEvent;
+import org.bukkit.event.world.ChunkUnloadEvent;
 import org.bukkit.event.world.PortalCreateEvent;
 import org.bukkit.event.world.StructureGrowEvent;
+
+import java.awt.*;
 
 public class WorldListener  implements Listener {
 
@@ -76,6 +79,27 @@ public class WorldListener  implements Listener {
 			}
 		}
 		konquest.applyQueuedTeleports(event.getChunk());
+	}
+
+	@EventHandler(priority = EventPriority.MONITOR)
+	public void onChunkUnload(ChunkUnloadEvent event) {
+		// Remove Ruin Golems when a chunk with a ruin spawn location unloads
+		Point chunkPoint = Konquest.toPoint(event.getChunk());
+		if(konquest.getTerritoryManager().isChunkClaimed(chunkPoint, event.getWorld())) {
+			KonTerritory territory = konquest.getTerritoryManager().getChunkTerritory(Konquest.toPoint(event.getChunk()), event.getWorld());
+			if(territory instanceof KonRuin) {
+				KonRuin ruin = (KonRuin) territory;
+				for(Location spawn : ruin.getSpawnLocations()) {
+					Point spawnPoint = Konquest.toPoint(spawn);
+					if(chunkPoint.equals(spawnPoint)) {
+						// Found a ruin's spawn point within the chunk being unloaded
+						// Remove the golem associated with the spawn point
+						ruin.removeGolem(spawn);
+					}
+				}
+			}
+		}
+
 	}
 	
 	@EventHandler(priority = EventPriority.HIGH)

--- a/core/src/main/java/com/github/rumsfield/konquest/manager/RuinManager.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/manager/RuinManager.java
@@ -43,6 +43,7 @@ public class RuinManager implements KonquestRuinManager {
 		for(KonRuin ruin : ruinMap.values()) {
 			ruin.regenCriticalBlocks();
 		}
+		ChatUtil.printDebug("Regenerated all ruin critical blocks");
 	}
 	
 	public void removeAllGolems() {
@@ -176,12 +177,6 @@ public class RuinManager implements KonquestRuinManager {
 	
 	public Material getRuinCriticalBlock() {
 		return ruinCriticalBlock;
-	}
-
-	public void regenAllCriticalBlocks() {
-		for(KonRuin ruin : ruinMap.values()) {
-			ruin.regenCriticalBlocks();
-		}
 	}
 	
 	private void loadCriticalBlocks() {

--- a/core/src/main/java/com/github/rumsfield/konquest/model/KonRuin.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/model/KonRuin.java
@@ -329,6 +329,10 @@ public class KonRuin extends KonTerritory implements KonquestRuin, KonBarDisplay
 		if(!isCaptureDisabled) {
 			// Spawn all golems
 			for(KonRuinGolem golem : spawnLocations.values()) {
+				// Remove golems outside of ruin territory
+				if(!this.isLocInside(golem.getLocation())) {
+					golem.remove();
+				}
 				golem.spawn();
 			}
 		}
@@ -379,6 +383,12 @@ public class KonRuin extends KonTerritory implements KonquestRuin, KonBarDisplay
 	public void removeAllGolems() {
 		for(KonRuinGolem golem : spawnLocations.values()) {
 			golem.remove();
+		}
+	}
+
+	public void removeGolem(Location spawn) {
+		if(spawnLocations.containsKey(spawn)) {
+			spawnLocations.get(spawn).remove();
 		}
 	}
 	

--- a/core/src/main/java/com/github/rumsfield/konquest/model/KonRuinGolem.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/model/KonRuinGolem.java
@@ -1,5 +1,6 @@
 package com.github.rumsfield.konquest.model;
 
+import com.github.rumsfield.konquest.utility.ChatUtil;
 import org.bukkit.Location;
 import org.bukkit.Sound;
 import org.bukkit.attribute.Attribute;
@@ -32,6 +33,11 @@ public class KonRuinGolem {
 		if(isRespawnCooldown)return;
 		if(golem == null || golem.isDead()) {
 			Location modLoc = new Location(spawnLoc.getWorld(),spawnLoc.getX()+0.5,spawnLoc.getY()+1.0,spawnLoc.getZ()+0.5);
+			// Load chunk if not already done
+			if(!modLoc.getChunk().isLoaded()) {
+				modLoc.getChunk().load();
+			}
+			// Spawn golem entity
 			golem = (IronGolem)spawnLoc.getWorld().spawnEntity(modLoc, EntityType.IRON_GOLEM);
 			golem.setPlayerCreated(true);
 			double defaultValue;
@@ -57,7 +63,20 @@ public class KonRuinGolem {
 	
 	public void remove() {
 		if(golem != null) {
-			golem.remove();
+			// Load the chunk of the entity to remove it
+			if(!golem.getLocation().getChunk().isEntitiesLoaded()) {
+				if(golem.getLocation().getChunk().load()) {
+					// Chunk loaded successfully
+					golem.remove();
+					ChatUtil.printDebug("Successfully removed golem in newly loaded chunk");
+				} else {
+					ChatUtil.printDebug("Failed to load chunk for golem removal");
+				}
+			} else {
+				// Entities are already loaded
+				golem.remove();
+				ChatUtil.printDebug("Successfully removed golem in previously loaded chunk");
+			}
 		}
 	}
 	


### PR DESCRIPTION
# Konquest Pull Request

Closes #114

## Summary
Modifies ruin golem mechanics: golems are removed when their spawn chunks unload, and respawn if they are outside of ruin territory when a player enters. Also regenerates critical blocks on server start and stop.

## Change Details
See issue.

## Checklist
- [x] I have merged the latest `develop` commit into this branch and resolved any conflicts.
- [x] I have tested this branch and it is working as intended.
- [x] This Pull Request is ready for review and merging.