### PR TITLE
Updated spigot api, added 1.20.2 support #140

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -34,7 +34,7 @@ repositories{
 }
 
 dependencies{
-    compileOnly("org.spigotmc:spigot-api:1.20.1-R0.1-SNAPSHOT")
+    compileOnly("org.spigotmc:spigot-api:1.20.2-R0.1-SNAPSHOT")
     compileOnly("org.spigotmc:spigot-api:1.16.5-R0.1-SNAPSHOT")
     compileOnly("org.spigotmc:spigot-1.17.1-R0.1-SNAPSHOT-remapped")
     compileOnly("org.spigotmc:spigot-1.16.5-R0.1-SNAPSHOT")

--- a/core/src/main/java/com/github/rumsfield/konquest/Konquest.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/Konquest.java
@@ -235,6 +235,7 @@ public class Konquest implements KonquestAPI, Timeable {
 				case "v1_19_R2":
 				case "v1_19_R3":
 				case "v1_20_R1":
+				case "v1_20_R2":
 					if(isProtocolLibEnabled) { versionHandler = new Handler_1_19_R1(); }
 	    			break;
 	    		default:


### PR DESCRIPTION
# Konquest Pull Request

Closes #140

## Summary
Adds support for Minecraft 1.20.2.

## Change Details
* Updates Spigot API version to 1.20.2.
* Adds version support check for `v1_20_R2`, using same version handler since 1.19.

## Checklist
- [x] I have merged the latest `develop` commit into this branch and resolved any conflicts.
- [x] I have tested this branch and it is working as intended.
- [x] This Pull Request is ready for review and merging.