### PR TITLE
Feature/141 kingdom town limit

### DIFF
--- a/core/src/main/java/com/github/rumsfield/konquest/command/SettleCommand.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/command/SettleCommand.java
@@ -68,6 +68,7 @@ public class SettleCommand extends CommandBase {
 			if(settleWorld != null) {
 				boolean isPerWorld = getKonquest().getCore().getBoolean(CorePath.KINGDOMS_MAX_TOWN_LIMIT_PER_WORLD.getPath(),false);
 				int maxTownLimit = getKonquest().getCore().getInt(CorePath.KINGDOMS_MAX_TOWN_LIMIT.getPath(),0);
+				maxTownLimit = Math.max(maxTownLimit,0); // clamp to 0 minimum
 				if(maxTownLimit != 0) {
 					int numTownsInWorld = 0;
 					if(isPerWorld) {

--- a/core/src/main/java/com/github/rumsfield/konquest/command/SettleCommand.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/command/SettleCommand.java
@@ -4,10 +4,7 @@ import com.github.rumsfield.konquest.Konquest;
 import com.github.rumsfield.konquest.KonquestPlugin;
 import com.github.rumsfield.konquest.api.event.player.KonquestPlayerSettleEvent;
 import com.github.rumsfield.konquest.api.event.town.KonquestTownSettleEvent;
-import com.github.rumsfield.konquest.model.KonDirective;
-import com.github.rumsfield.konquest.model.KonPlayer;
-import com.github.rumsfield.konquest.model.KonStatsType;
-import com.github.rumsfield.konquest.model.KonTown;
+import com.github.rumsfield.konquest.model.*;
 import com.github.rumsfield.konquest.utility.ChatUtil;
 import com.github.rumsfield.konquest.utility.CorePath;
 import com.github.rumsfield.konquest.utility.MessagePath;
@@ -65,8 +62,38 @@ public class SettleCommand extends CommandBase {
 					}
 				}
 			}
-        	
-        	double cost = getKonquest().getCore().getDouble(CorePath.FAVOR_TOWNS_COST_SETTLE.getPath());
+			// Check max town limit
+			KonKingdom settleKingdom = player.getKingdom();
+			World settleWorld = bukkitPlayer.getLocation().getWorld();
+			if(settleWorld != null) {
+				boolean isPerWorld = getKonquest().getCore().getBoolean(CorePath.KINGDOMS_MAX_TOWN_LIMIT_PER_WORLD.getPath(),false);
+				int maxTownLimit = getKonquest().getCore().getInt(CorePath.KINGDOMS_MAX_TOWN_LIMIT.getPath(),0);
+				if(maxTownLimit != 0) {
+					int numTownsInWorld = 0;
+					if(isPerWorld) {
+						// Find towns within the given world
+						for(KonTown town : settleKingdom.getCapitalTowns()) {
+							if(town.getWorld().equals(settleWorld)) {
+								numTownsInWorld++;
+							}
+						}
+					} else {
+						// Find all towns
+						numTownsInWorld = settleKingdom.getCapitalTowns().size();
+					}
+					if(numTownsInWorld >= maxTownLimit) {
+						// Limit reached
+						if(isPerWorld) {
+							ChatUtil.sendError(bukkitPlayer, MessagePath.COMMAND_SETTLE_ERROR_FAIL_LIMIT_WORLD.getMessage(numTownsInWorld,maxTownLimit));
+						} else {
+							ChatUtil.sendError(bukkitPlayer, MessagePath.COMMAND_SETTLE_ERROR_FAIL_LIMIT_ALL.getMessage(numTownsInWorld,maxTownLimit));
+						}
+						return;
+					}
+				}
+			}
+
+			double cost = getKonquest().getCore().getDouble(CorePath.FAVOR_TOWNS_COST_SETTLE.getPath());
         	double incr = getKonquest().getCore().getDouble(CorePath.FAVOR_TOWNS_COST_SETTLE_INCREMENT.getPath());
         	int townCount = getKonquest().getKingdomManager().getPlayerLordships(player);
         	double adj_cost = (((double)townCount)*incr) + cost;

--- a/core/src/main/java/com/github/rumsfield/konquest/utility/CorePath.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/utility/CorePath.java
@@ -98,6 +98,8 @@ public enum CorePath {
 	KINGDOMS_GOLEM_ATTACK_ENEMIES                         ("core.kingdoms.golem_attack_enemies"),
 	KINGDOMS_ATTACK_FRIENDLY_GOLEMS                       ("core.kingdoms.attack_friendly_golems"),
 	KINGDOMS_MAX_PLAYER_DIFF                              ("core.kingdoms.max_player_diff"),
+	KINGDOMS_MAX_TOWN_LIMIT                               ("core.kingdoms.max_town_limit"),
+	KINGDOMS_MAX_TOWN_LIMIT_PER_WORLD                     ("core.kingdoms.max_town_limit_per_world"),
 	KINGDOMS_ALLOW_EXILE_SWITCH                           ("core.kingdoms.allow_exile_switch"),
 	KINGDOMS_EXILE_COOLDOWN                               ("core.kingdoms.exile_cooldown"),
 	KINGDOMS_JOIN_COOLDOWN                                ("core.kingdoms.join_cooldown"),

--- a/core/src/main/java/com/github/rumsfield/konquest/utility/MessagePath.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/utility/MessagePath.java
@@ -583,6 +583,8 @@ public enum MessagePath {
 	COMMAND_SETTLE_ERROR_FAIL_WATER             (0, "command.settle.error.fail-water"),
 	COMMAND_SETTLE_ERROR_FAIL_CONTAINER         (0, "command.settle.error.fail-container"),
 	COMMAND_SETTLE_ERROR_FAIL_INIT              (0, "command.settle.error.fail-init"),
+	COMMAND_SETTLE_ERROR_FAIL_LIMIT_ALL         (2, "command.settle.error.fail-limit-all"),
+	COMMAND_SETTLE_ERROR_FAIL_LIMIT_WORLD       (2, "command.settle.error.fail-limit-world"),
 	COMMAND_SPY_NOTICE_NEARBY                   (0, "command.spy.notice.nearby"),
 	COMMAND_SPY_NOTICE_REGIONAL                 (0, "command.spy.notice.regional"),
 	COMMAND_SPY_NOTICE_FARAWAY                  (0, "command.spy.notice.faraway"),

--- a/core/src/main/resources/core.yml
+++ b/core/src/main/resources/core.yml
@@ -326,6 +326,12 @@ core:
     
     # Kingdoms with this many players more than other Kingdoms will not accept new players (0 to disable, integer >= 0)
     max_player_diff: 0
+
+    # The maximum number of towns, including the capital, that a Kingdom can settle (0 to disable, integer >= 0)
+    max_town_limit: 0
+
+    # Whether the maximum town limit applies only in each world (true) or across all worlds (false) (true/false)
+    max_town_limit_per_world: false
     
     # Allow barbarians to join any kingdom, even when exiled (true) or prevent exiled barbarians from switching kingdoms (false) (true/false)
     allow_exile_switch: true

--- a/core/src/main/resources/lang/english.yml
+++ b/core/src/main/resources/lang/english.yml
@@ -661,6 +661,8 @@ command:
       fail-water: "Too much water below the ground. Try settling somewhere else, or remove all water below you."
       fail-container: "Too many containers below the ground. Try settling somewhere else, or remove all containers below you."
       fail-init: "Town could not claim initial chunks."
+      fail-limit-all: "Cannot settle more towns than the global maximum limit of %s. There are currently %s towns in all worlds."
+      fail-limit-world: "Cannot settle more towns than the per-world maximum limit of %s. There are currently %s towns in this world."
   spy:
     notice:
       nearby: "nearby"


### PR DESCRIPTION
# Konquest Pull Request

Closes #141

## Summary
Adds options for maximum town limits for all kingdoms, either per-world or global.

## Change Details
* Adds new core.yml options `core.kingdoms.max_town_limit` and `core.kingdoms.max_town_limit_per_world`.
* Adds new english.yml messages for errors related to max town limits.
* Adds check to settle command for whether the player's kingdom has reached the maximum town limit.

## Checklist
- [x] I have merged the latest `develop` commit into this branch and resolved any conflicts.
- [x] I have tested this branch and it is working as intended.
- [x] This Pull Request is ready for review and merging.