### PR TITLE
Bugfix/137 kingdom membership barbarians

### DIFF
--- a/core/src/main/java/com/github/rumsfield/konquest/display/wrapper/KingdomInfoMenuWrapper.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/display/wrapper/KingdomInfoMenuWrapper.java
@@ -324,6 +324,9 @@ public class KingdomInfoMenuWrapper extends MenuWrapper {
 			KonOfflinePlayer offlinePlayer = getKonquest().getPlayerManager().getOfflinePlayer(icon.getOfflinePlayer());
 			if(offlinePlayer != null && icon.getAction().equals(PlayerIconAction.DISPLAY_INFO)) {
 				getKonquest().getDisplayManager().displayPlayerInfoMenu(clickPlayer, offlinePlayer);
+			} else {
+				ChatUtil.sendError(clickPlayer.getBukkitPlayer(),MessagePath.GENERIC_ERROR_INTERNAL.getMessage());
+				ChatUtil.printConsoleWarning("Failed to open info menu for unknown player "+icon.getOfflinePlayer().getName()+". Check your SQL database settings in core.yml, the database connection may have been lost or corrupted.");
 			}
 		} else if(clickedIcon instanceof KingdomIcon) {
 			// Kingdom Icons open a new kingdom info menu for the associated player

--- a/core/src/main/java/com/github/rumsfield/konquest/display/wrapper/PlayerInfoMenuWrapper.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/display/wrapper/PlayerInfoMenuWrapper.java
@@ -137,6 +137,9 @@ public class PlayerInfoMenuWrapper extends MenuWrapper {
 			KonOfflinePlayer offlinePlayer = getKonquest().getPlayerManager().getOfflinePlayer(icon.getOfflinePlayer());
 			if(offlinePlayer != null && icon.getAction().equals(PlayerIconAction.DISPLAY_SCORE)) {
 				getKonquest().getDisplayManager().displayScoreMenu(clickPlayer, offlinePlayer);
+			} else {
+				ChatUtil.sendError(clickPlayer.getBukkitPlayer(),MessagePath.GENERIC_ERROR_INTERNAL.getMessage());
+				ChatUtil.printConsoleWarning("Failed to open score menu for unknown player "+icon.getOfflinePlayer().getName()+". Check your SQL database settings in core.yml, the database connection may have been lost or corrupted.");
 			}
 		} else if(clickedIcon instanceof KingdomIcon) {
 			// Kingdom Icons open a new kingdom info menu for the associated player

--- a/core/src/main/java/com/github/rumsfield/konquest/display/wrapper/ScoreMenuWrapper.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/display/wrapper/ScoreMenuWrapper.java
@@ -136,6 +136,9 @@ public class ScoreMenuWrapper extends MenuWrapper {
 					default:
 						break;
 				}
+			} else {
+				ChatUtil.sendError(clickPlayer.getBukkitPlayer(),MessagePath.GENERIC_ERROR_INTERNAL.getMessage());
+				ChatUtil.printConsoleWarning("Failed to open info menu for unknown player "+icon.getOfflinePlayer().getName()+". Check your SQL database settings in core.yml, the database connection may have been lost or corrupted.");
 			}
 		} else if(clickedIcon instanceof KingdomIcon) {
 			// Kingdom Icons open a new kingdom info menu for the associated player

--- a/core/src/main/java/com/github/rumsfield/konquest/display/wrapper/TownInfoMenuWrapper.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/display/wrapper/TownInfoMenuWrapper.java
@@ -238,6 +238,9 @@ public class TownInfoMenuWrapper extends MenuWrapper {
 			KonOfflinePlayer offlinePlayer = getKonquest().getPlayerManager().getOfflinePlayer(icon.getOfflinePlayer());
 			if(offlinePlayer != null && icon.getAction().equals(PlayerIconAction.DISPLAY_INFO)) {
 				getKonquest().getDisplayManager().displayPlayerInfoMenu(clickPlayer, offlinePlayer);
+			} else {
+				ChatUtil.sendError(clickPlayer.getBukkitPlayer(),MessagePath.GENERIC_ERROR_INTERNAL.getMessage());
+				ChatUtil.printConsoleWarning("Failed to open info menu for unknown player "+icon.getOfflinePlayer().getName()+". Check your SQL database settings in core.yml, the database connection may have been lost or corrupted.");
 			}
 		}
 	}

--- a/core/src/main/java/com/github/rumsfield/konquest/manager/PlayerManager.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/manager/PlayerManager.java
@@ -99,7 +99,7 @@ public class PlayerManager implements KonquestPlayerManager {
 				newPlayer.setKingdom(kingdom);
 				newPlayer.setExileKingdom(kingdom);
 				newPlayer.setBarbarian(false);
-				ChatUtil.printDebug("New player has existing kingdom membership with "+kingdom.getName());
+				ChatUtil.printConsoleWarning("New player "+bukkitPlayer.getName()+" already has kingdom membership in "+kingdom.getName()+". Check your SQL database settings in core.yml, the database connection may have been lost or corrupted.");
 				break;
 			}
 		}
@@ -132,7 +132,7 @@ public class PlayerManager implements KonquestPlayerManager {
 					importedPlayer.setKingdom(kingdom);
 					importedPlayer.setExileKingdom(kingdom);
 					importedPlayer.setBarbarian(false);
-					ChatUtil.printDebug("Imported barbarian player has existing kingdom membership with "+kingdom.getName());
+					ChatUtil.printConsoleWarning("Existing barbarian player "+bukkitPlayer.getName()+" has kingdom membership in "+kingdom.getName()+". Check your SQL database settings in core.yml, the database connection may have been lost or corrupted.");
 					break;
 				}
 			}
@@ -155,7 +155,7 @@ public class PlayerManager implements KonquestPlayerManager {
 						importedPlayer.setKingdom(kingdom);
 						importedPlayer.setExileKingdom(kingdom);
 						importedPlayer.setBarbarian(false);
-						ChatUtil.printDebug("Imported non-barbarian player with missing kingdom has existing kingdom membership with "+kingdom.getName());
+						ChatUtil.printConsoleWarning("Existing player "+bukkitPlayer.getName()+" is in an unknown kingdom, but already has kingdom membership in "+kingdom.getName()+". Check your SQL database settings in core.yml, the database connection may have been lost or corrupted.");
 						break;
 					}
 				}

--- a/core/src/main/java/com/github/rumsfield/konquest/manager/PlayerManager.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/manager/PlayerManager.java
@@ -83,16 +83,29 @@ public class PlayerManager implements KonquestPlayerManager {
 	}
 	
 	/**
-	 * This method is used for creating a new KonPlayer that has never joined before
+	 * This method is used for creating a new KonPlayer that has never joined before.
+	 * Once the new player is created, attempt to match it to existing memberships in kingdoms/towns.
 	 * @param bukkitPlayer - Bukkit player
 	 * @return KonPlayer of the bukkit player
 	 */
 	@NotNull
 	public KonPlayer createKonPlayer(Player bukkitPlayer) {
 		KonPlayer newPlayer = new KonPlayer(bukkitPlayer, konquest.getKingdomManager().getBarbarians(), true);
-        onlinePlayers.put(bukkitPlayer, newPlayer);
-        linkOnlinePlayerToCache(newPlayer);
-        ChatUtil.printDebug("Created player "+bukkitPlayer.getName());
+		// Attempt to match existing memberships
+		UUID id = bukkitPlayer.getUniqueId();
+		for(KonKingdom kingdom : konquest.getKingdomManager().getKingdoms()) {
+			if(kingdom.isMember(id)) {
+				// Found a kingdom membership, update player's data
+				newPlayer.setKingdom(kingdom);
+				newPlayer.setExileKingdom(kingdom);
+				newPlayer.setBarbarian(false);
+				ChatUtil.printDebug("New player has existing kingdom membership with "+kingdom.getName());
+				break;
+			}
+		}
+		onlinePlayers.put(bukkitPlayer, newPlayer);
+		linkOnlinePlayerToCache(newPlayer);
+		ChatUtil.printDebug("Created player "+bukkitPlayer.getName());
         return newPlayer;
     }
 	
@@ -107,11 +120,22 @@ public class PlayerManager implements KonquestPlayerManager {
 	@NotNull
 	public KonPlayer importKonPlayer(Player bukkitPlayer, String kingdomName, String exileKingdomName, boolean isBarbarian) {
 		KonPlayer importedPlayer;
-
+		UUID id = bukkitPlayer.getUniqueId();
     	// Create KonPlayer instance
     	if(isBarbarian) {
     		// Player data has barbarian flag set true, create barbarian player
     		importedPlayer = new KonPlayer(bukkitPlayer, konquest.getKingdomManager().getBarbarians(), true);
+			// Attempt to match existing memberships
+			for(KonKingdom kingdom : konquest.getKingdomManager().getKingdoms()) {
+				if(kingdom.isMember(id)) {
+					// Found a kingdom membership, update player's data
+					importedPlayer.setKingdom(kingdom);
+					importedPlayer.setExileKingdom(kingdom);
+					importedPlayer.setBarbarian(false);
+					ChatUtil.printDebug("Imported barbarian player has existing kingdom membership with "+kingdom.getName());
+					break;
+				}
+			}
     	} else {
     		// Player's barbarian flag is false, should belong to a kingdom
     		KonKingdom playerKingdom = konquest.getKingdomManager().getKingdom(kingdomName);
@@ -120,12 +144,25 @@ public class PlayerManager implements KonquestPlayerManager {
 			if(playerKingdom.equals(konquest.getKingdomManager().getBarbarians())) {
 				// The player's kingdom does not exist
 				// Possibly renamed or removed
-				//TODO: Search for any other kingdoms with membership?
 				// When a kingdom is renamed, all offline players have their database entry updated with the new kingdom name.
-				// For now, just make them into a barbarian.
 				importedPlayer = new KonPlayer(bukkitPlayer, konquest.getKingdomManager().getBarbarians(), true);
-				ChatUtil.sendNotice(bukkitPlayer, MessagePath.GENERIC_NOTICE_FORCE_BARBARIAN.getMessage());
-				ChatUtil.printDebug("Forced non-barbarian player with missing kingdom to become a barbarian");
+
+				// Attempt to match existing memberships
+				boolean foundMembership = false;
+				for(KonKingdom kingdom : konquest.getKingdomManager().getKingdoms()) {
+					if(kingdom.isMember(id)) {
+						// Found a kingdom membership, update player's data
+						importedPlayer.setKingdom(kingdom);
+						importedPlayer.setExileKingdom(kingdom);
+						importedPlayer.setBarbarian(false);
+						ChatUtil.printDebug("Imported non-barbarian player with missing kingdom has existing kingdom membership with "+kingdom.getName());
+						break;
+					}
+				}
+				if(!foundMembership) {
+					ChatUtil.sendNotice(bukkitPlayer, MessagePath.GENERIC_NOTICE_FORCE_BARBARIAN.getMessage());
+					ChatUtil.printDebug("Forced non-barbarian player with missing kingdom to become a barbarian");
+				}
 			} else {
 				// The player's kingdom was found
 				if(playerKingdom.isMember(bukkitPlayer.getUniqueId())) {
@@ -134,7 +171,6 @@ public class PlayerManager implements KonquestPlayerManager {
 				} else {
 					// The player is not a member of their kingdom
 					// Possibly kicked or renamed
-					//TODO: Search for any other kingdoms with membership?
 					// The most likely scenario is that the player was kicked.
 					// Just make them a barbarian.
 					importedPlayer = new KonPlayer(bukkitPlayer, konquest.getKingdomManager().getBarbarians(), true);


### PR DESCRIPTION
# Konquest Pull Request

Closes #137 

## Summary
Adds checks for existing kingdom memberships for players that join the server.

## Change Details
* Updated player import logic to update the player's database kingdom assignment when an existing membership is found under certain conditions. This is to help keep memberships intact when the SQL database connection has been lost.
* Added console warning messages for when new players join with existing memberships, and other conditions which may indicate a lost or corrupt SQL database connection.

## Checklist
- [x] I have merged the latest `develop` commit into this branch and resolved any conflicts.
- [x] I have tested this branch and it is working as intended.
- [x] This Pull Request is ready for review and merging.