### PR TITLE
Feature/151 all pvp flag

### DIFF
--- a/core/src/main/java/com/github/rumsfield/konquest/command/admin/FlagAdminCommand.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/command/admin/FlagAdminCommand.java
@@ -228,6 +228,10 @@ public class FlagAdminCommand extends CommandBase {
 						if(setHolder.setPropertyValue(flag, bValue)) {
 							// Successfully assigned value
 							ChatUtil.sendNotice(bukkitPlayer, MessagePath.COMMAND_ADMIN_FLAG_NOTICE_SET.getMessage(flag.getName(), holderName, bValue));
+							if(flag.equals(KonPropertyFlag.ARENA) && (setHolder instanceof KonSanctuary || setHolder instanceof KonRuin)) {
+								// Update title bar
+								((KonBarDisplayer) setHolder).updateBarTitle();
+							}
 						} else {
 							// Failed to assign value
 							ChatUtil.sendError(bukkitPlayer, MessagePath.GENERIC_ERROR_FAILED.getMessage());

--- a/core/src/main/java/com/github/rumsfield/konquest/hook/WorldGuardExec.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/hook/WorldGuardExec.java
@@ -23,6 +23,7 @@ import java.awt.*;
  */
 public class WorldGuardExec {
 
+    private static StateFlag ARENA;
     private static StateFlag CLAIM;
     private static StateFlag UNCLAIM;
     private static StateFlag TRAVEL_ENTER;
@@ -37,48 +38,65 @@ public class WorldGuardExec {
     public static boolean load() {
         isAvailable = false;
         FlagRegistry registry = WorldGuard.getInstance().getFlagRegistry();
+        String errorMessageFormat = "Konquest failed to register a custom flag with WorldGuard, %s, because another plugin has already registered it.";
+
+        /* Arena Flag */
+        String flagNameArena = "konquest-arena";
+        try {
+            StateFlag flag = new StateFlag(flagNameArena, true);
+            registry.register(flag);
+            ARENA = flag;
+        } catch (FlagConflictException e) {
+            // some other plugin registered a flag by the same name already.
+            ChatUtil.printConsoleError(String.format(errorMessageFormat, flagNameArena));
+            return false;
+        }
 
         /* Claim Flag */
+        String flagNameClaim = "konquest-claim";
         try {
-            StateFlag flag = new StateFlag("konquest-claim", true);
+            StateFlag flag = new StateFlag(flagNameClaim, true);
             registry.register(flag);
             CLAIM = flag;
         } catch (FlagConflictException e) {
             // some other plugin registered a flag by the same name already.
-            ChatUtil.printConsoleError("Konquest failed to register a custom flag with WorldGuard, konquest-claim, because another plugin has already registered it.");
+            ChatUtil.printConsoleError(String.format(errorMessageFormat, flagNameClaim));
             return false;
         }
 
         /* Unclaim Flag */
+        String flagNameUnclaim = "konquest-unclaim";
         try {
-            StateFlag flag = new StateFlag("konquest-unclaim", true);
+            StateFlag flag = new StateFlag(flagNameUnclaim, true);
             registry.register(flag);
             UNCLAIM = flag;
         } catch (FlagConflictException e) {
             // some other plugin registered a flag by the same name already.
-            ChatUtil.printConsoleError("Konquest failed to register a custom flag with WorldGuard, konquest-unclaim, because another plugin has already registered it.");
+            ChatUtil.printConsoleError(String.format(errorMessageFormat, flagNameUnclaim));
             return false;
         }
 
         /* Travel Enter Flag */
+        String flagNameTravelEnter = "konquest-travel-enter";
         try {
-            StateFlag flag = new StateFlag("konquest-travel-enter", true);
+            StateFlag flag = new StateFlag(flagNameTravelEnter, true);
             registry.register(flag);
             TRAVEL_ENTER = flag;
         } catch (FlagConflictException e) {
             // some other plugin registered a flag by the same name already.
-            ChatUtil.printConsoleError("Konquest failed to register a custom flag with WorldGuard, konquest-travel-enter, because another plugin has already registered it.");
+            ChatUtil.printConsoleError(String.format(errorMessageFormat, flagNameTravelEnter));
             return false;
         }
 
         /* Travel Exit Flag */
+        String flagNameTravelExit = "konquest-travel-exit";
         try {
-            StateFlag flag = new StateFlag("konquest-travel-exit", true);
+            StateFlag flag = new StateFlag(flagNameTravelExit, true);
             registry.register(flag);
             TRAVEL_EXIT = flag;
         } catch (FlagConflictException e) {
             // some other plugin registered a flag by the same name already.
-            ChatUtil.printConsoleError("Konquest failed to register a custom flag with WorldGuard, konquest-travel-exit, because another plugin has already registered it.");
+            ChatUtil.printConsoleError(String.format(errorMessageFormat, flagNameTravelExit));
             return false;
         }
 
@@ -117,17 +135,21 @@ public class WorldGuardExec {
     }
 
     static boolean isLocationTravelEnterAllowed(Location loc, Player player) {
-        return isLocationFlagAllowed(TRAVEL_ENTER, loc, player);
+        return isLocationFlagAllowed(TRAVEL_ENTER, loc, player, true);
     }
 
     static boolean isLocationTravelExitAllowed(Location loc, Player player) {
-        return isLocationFlagAllowed(TRAVEL_EXIT, loc, player);
+        return isLocationFlagAllowed(TRAVEL_EXIT, loc, player, true);
     }
 
-    private static boolean isLocationFlagAllowed(StateFlag flag, Location loc, Player player) {
+    static boolean isLocationArenaAllowed(Location loc, Player player) {
+        return isLocationFlagAllowed(ARENA, loc, player, false);
+    }
+
+    private static boolean isLocationFlagAllowed(StateFlag flag, Location loc, Player player, boolean defaultResult) {
         if(!isAvailable) {
-            // WorldGuard integration did not register custom flags, always allow
-            return true;
+            // WorldGuard integration did not register custom flags, use default result
+            return defaultResult;
         }
         assert loc.getWorld() != null;
         RegionContainer container = WorldGuard.getInstance().getPlatform().getRegionContainer();

--- a/core/src/main/java/com/github/rumsfield/konquest/hook/WorldGuardExec.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/hook/WorldGuardExec.java
@@ -43,7 +43,7 @@ public class WorldGuardExec {
         /* Arena Flag */
         String flagNameArena = "konquest-arena";
         try {
-            StateFlag flag = new StateFlag(flagNameArena, true);
+            StateFlag flag = new StateFlag(flagNameArena, false);
             registry.register(flag);
             ARENA = flag;
         } catch (FlagConflictException e) {
@@ -155,8 +155,8 @@ public class WorldGuardExec {
         RegionContainer container = WorldGuard.getInstance().getPlatform().getRegionContainer();
         RegionManager regions = container.get(BukkitAdapter.adapt(loc.getWorld()));
         if(regions == null) {
-            // No regions available in this world, always allow
-            return true;
+            // No regions available in this world, use default
+            return defaultResult;
         }
         BlockVector3 pos = BlockVector3.at(loc.getX(),loc.getY(),loc.getZ());
         ApplicableRegionSet overlappingChunkRegions = regions.getApplicableRegions(pos);

--- a/core/src/main/java/com/github/rumsfield/konquest/hook/WorldGuardHook.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/hook/WorldGuardHook.java
@@ -95,4 +95,12 @@ public class WorldGuardHook implements PluginHook {
         return WorldGuardExec.isLocationTravelExitAllowed(loc, player);
     }
 
+    public boolean isLocationArenaAllowed(Location loc, Player player) {
+        if(!isEnabled) {
+            // WorldGuard integration is disabled, always deny
+            return false;
+        }
+        return WorldGuardExec.isLocationArenaAllowed(loc, player);
+    }
+
 }

--- a/core/src/main/java/com/github/rumsfield/konquest/listener/EntityListener.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/listener/EntityListener.java
@@ -663,70 +663,89 @@ public class EntityListener implements Listener {
             if(victimPlayer == null || attackerPlayer == null) {
             	return;
             }
-			// Protect victim if they're peaceful
-			if(victimPlayer.getKingdom().isPeaceful()) {
-				ChatUtil.sendNotice(attackerBukkitPlayer, MessagePath.PROTECTION_NOTICE_PEACEFUL_VICTIM.getMessage());
-				event.setCancelled(true);
-				return;
+
+			// Update egg stat
+			if(isEggAttack) {
+				konquest.getAccomplishmentManager().modifyPlayerStat(attackerPlayer,KonStatsType.EGG,1);
 			}
-			// Protect victim when attacker is peaceful
-			if(attackerPlayer.getKingdom().isPeaceful()) {
-				ChatUtil.sendNotice(attackerBukkitPlayer, MessagePath.PROTECTION_NOTICE_PEACEFUL_ATTACKER.getMessage());
-				event.setCancelled(true);
-				return;
-			}
-            // Check for protections for attacks within claimed territory
+
+            // Check for property flags
             boolean isWildDamageEnabled = konquest.getCore().getBoolean(CorePath.KINGDOMS_WILD_PVP.getPath(), true);
 			boolean isWorldValid = konquest.isWorldValid(victimBukkitPlayer.getLocation());
             boolean isAttackInTerritory = territoryManager.isChunkClaimed(victimBukkitPlayer.getLocation());
 			boolean isVictimInsideFriendlyTerritory = false;
-            if(isAttackInTerritory) {
-            	KonTerritory territory = territoryManager.getChunkTerritory(victimBukkitPlayer.getLocation());
+			boolean isPropertyPvpProtected = false; // True = no pvp is allowed at all, False = use normal pvp checks
+			boolean isPropertyArenaEnabled = false; // True = ignore kingdom relations for pvp, False = use normal relations checks
+			if(isAttackInTerritory) {
+				KonTerritory territory = territoryManager.getChunkTerritory(victimBukkitPlayer.getLocation());
 				assert territory != null;
-            	// Property Flag Holders
-    			if(territory instanceof KonPropertyFlagHolder) {
-    				KonPropertyFlagHolder flagHolder = (KonPropertyFlagHolder)territory;
-    				if(flagHolder.hasPropertyValue(KonPropertyFlag.PVP)) {
-    					if(!flagHolder.getPropertyValue(KonPropertyFlag.PVP)) {
-    						ChatUtil.sendKonPriorityTitle(attackerPlayer, "", Konquest.blockedFlagColor+MessagePath.PROTECTION_ERROR_BLOCKED.getMessage(), 1, 10, 10);
-    						event.setCancelled(true);
-    						return;
-    					}
-    				}
-    			}
-            	// Prevent damage to victim inside peaceful territory if the victim is a member
+				// Property Flag Holders
+				if(territory instanceof KonPropertyFlagHolder) {
+					KonPropertyFlagHolder flagHolder = (KonPropertyFlagHolder)territory;
+					if(flagHolder.hasPropertyValue(KonPropertyFlag.PVP)) {
+						if(!flagHolder.getPropertyValue(KonPropertyFlag.PVP)) {
+							isPropertyPvpProtected = true;
+						}
+					}
+					if(flagHolder.hasPropertyValue(KonPropertyFlag.ARENA)) {
+						if(flagHolder.getPropertyValue(KonPropertyFlag.ARENA)) {
+							isPropertyArenaEnabled = true;
+						}
+					}
+				}
+				// Other territory checks
 				isVictimInsideFriendlyTerritory = territory.getKingdom().equals(victimPlayer.getKingdom());
-            	if(territory.getKingdom().isPeaceful() && isVictimInsideFriendlyTerritory) {
-            		event.setCancelled(true);
-                	return;
-            	}
-            } else if(!isWildDamageEnabled && isWorldValid) {
-            	event.setCancelled(true);
-            	return;
-            }
-            
-            // Update egg stat
-            if(isEggAttack) {
-            	konquest.getAccomplishmentManager().modifyPlayerStat(attackerPlayer,KonStatsType.EGG,1);
-            }
-            
-            // Prevent optional damage based on relations
-			// Kingdoms at peace may allow pvp. Kingdoms in alliance or trade cannot pvp.
-			boolean isAllDamageEnabled = konquest.getCore().getBoolean(CorePath.KINGDOMS_ALLOW_ALL_PVP.getPath(), false);
-            boolean isPeaceDamageEnabled = konquest.getCore().getBoolean(CorePath.KINGDOMS_ALLOW_PEACEFUL_PVP.getPath(), false);
-			boolean isPlayerEnemy = true;
-			KonquestRelationshipType attackerRole = kingdomManager.getRelationRole(attackerPlayer.getKingdom(), victimPlayer.getKingdom());
-            if(attackerRole.equals(KonquestRelationshipType.FRIENDLY) ||
-            		attackerRole.equals(KonquestRelationshipType.ALLY) ||
-					attackerRole.equals(KonquestRelationshipType.TRADE) ||
-            		(attackerRole.equals(KonquestRelationshipType.PEACEFUL) && (!isPeaceDamageEnabled || isVictimInsideFriendlyTerritory))) {
-				isPlayerEnemy = false;
-            }
-			if(!isAllDamageEnabled && !isPlayerEnemy) {
-				ChatUtil.sendKonPriorityTitle(attackerPlayer, "", Konquest.blockedProtectionColor+MessagePath.PROTECTION_ERROR_BLOCKED.getMessage(), 1, 10, 10);
+			} else if(!isWildDamageEnabled && isWorldValid) {
+				// Always disable PVP in the wild when configured
 				event.setCancelled(true);
 				return;
 			}
+
+			// Check for WorldGuard flags
+			boolean isFlagArenaAllowed = konquest.getIntegrationManager().getWorldGuard().isLocationTravelExitAllowed(victimBukkitPlayer.getLocation(),attackerBukkitPlayer);
+
+			// Check for kingdom relationships
+			boolean isAllDamageEnabled = konquest.getCore().getBoolean(CorePath.KINGDOMS_ALLOW_ALL_PVP.getPath(), false);
+			boolean isPeaceDamageEnabled = konquest.getCore().getBoolean(CorePath.KINGDOMS_ALLOW_PEACEFUL_PVP.getPath(), false);
+			boolean isPlayerEnemy = true;
+			KonquestRelationshipType attackerRole = kingdomManager.getRelationRole(attackerPlayer.getKingdom(), victimPlayer.getKingdom());
+			if (attackerRole.equals(KonquestRelationshipType.FRIENDLY) ||
+					attackerRole.equals(KonquestRelationshipType.ALLY) ||
+					attackerRole.equals(KonquestRelationshipType.TRADE) ||
+					(attackerRole.equals(KonquestRelationshipType.PEACEFUL) && (!isPeaceDamageEnabled || isVictimInsideFriendlyTerritory))) {
+				isPlayerEnemy = false;
+			}
+
+			// Protection checks when the damage is not inside a territory with ARENA property = true
+			if(!isPropertyArenaEnabled && !isFlagArenaAllowed) {
+				// Protect victim if they're peaceful
+				if (victimPlayer.getKingdom().isPeaceful()) {
+					ChatUtil.sendNotice(attackerBukkitPlayer, MessagePath.PROTECTION_NOTICE_PEACEFUL_VICTIM.getMessage());
+					event.setCancelled(true);
+					return;
+				}
+				// Protect victim when attacker is peaceful
+				if (attackerPlayer.getKingdom().isPeaceful()) {
+					ChatUtil.sendNotice(attackerBukkitPlayer, MessagePath.PROTECTION_NOTICE_PEACEFUL_ATTACKER.getMessage());
+					event.setCancelled(true);
+					return;
+				}
+				// Protect pvp when property is false
+				if (isPropertyPvpProtected) {
+					ChatUtil.sendKonPriorityTitle(attackerPlayer, "", Konquest.blockedFlagColor + MessagePath.PROTECTION_ERROR_BLOCKED.getMessage(), 1, 10, 10);
+					event.setCancelled(true);
+					return;
+				}
+				// Prevent optional damage based on relations
+				// Kingdoms at peace may allow pvp. Kingdoms in alliance or trade cannot pvp.
+				if (!isAllDamageEnabled && !isPlayerEnemy) {
+					ChatUtil.sendKonPriorityTitle(attackerPlayer, "", Konquest.blockedProtectionColor + MessagePath.PROTECTION_ERROR_BLOCKED.getMessage(), 1, 10, 10);
+					event.setCancelled(true);
+					return;
+				}
+			}
+			/* Finished with protection checks, the victim is damaged...*/
+
 			// The victim may or may not be an enemy. Only do updates for enemy players.
             if (isPlayerEnemy) {
 				// Check for death, update directive progress & stat

--- a/core/src/main/java/com/github/rumsfield/konquest/listener/EntityListener.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/listener/EntityListener.java
@@ -702,7 +702,7 @@ public class EntityListener implements Listener {
 			}
 
 			// Check for WorldGuard flags
-			boolean isFlagArenaAllowed = konquest.getIntegrationManager().getWorldGuard().isLocationTravelExitAllowed(victimBukkitPlayer.getLocation(),attackerBukkitPlayer);
+			boolean isFlagArenaAllowed = konquest.getIntegrationManager().getWorldGuard().isLocationArenaAllowed(victimBukkitPlayer.getLocation(),attackerBukkitPlayer);
 
 			// Check for kingdom relationships
 			boolean isAllDamageEnabled = konquest.getCore().getBoolean(CorePath.KINGDOMS_ALLOW_ALL_PVP.getPath(), false);

--- a/core/src/main/java/com/github/rumsfield/konquest/listener/EntityListener.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/listener/EntityListener.java
@@ -715,6 +715,8 @@ public class EntityListener implements Listener {
 					(attackerRole.equals(KonquestRelationshipType.PEACEFUL) && (!isPeaceDamageEnabled || isVictimInsideFriendlyTerritory))) {
 				isPlayerEnemy = false;
 			}
+//			ChatUtil.printDebug("Player "+attackerBukkitPlayer.getName()+" attacked "+victimBukkitPlayer.getName()+
+//					", role="+attackerRole+", enemy="+isPlayerEnemy+", arenaProperty="+isPropertyArenaEnabled+", arenaFlag="+isFlagArenaAllowed);
 
 			// Protection checks when the damage is not inside a territory with ARENA property = true
 			if(!isPropertyArenaEnabled && !isFlagArenaAllowed) {

--- a/core/src/main/java/com/github/rumsfield/konquest/manager/KingdomManager.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/manager/KingdomManager.java
@@ -4456,8 +4456,10 @@ public class KingdomManager implements KonquestKingdomManager, Timeable {
 			kingdomSection.set("webcolor",kingdom.getWebColor());
 			// Kingdom Properties
 			ConfigurationSection kingdomPropertiesSection = kingdomSection.createSection("properties");
-			for(KonPropertyFlag flag : kingdom.getAllProperties().keySet()) {
-				kingdomPropertiesSection.set(flag.toString(), kingdom.getAllProperties().get(flag));
+			for(KonPropertyFlag flag : KonPropertyFlag.values()) {
+				if(kingdom.hasPropertyValue(flag)) {
+					kingdomPropertiesSection.set(flag.toString(), kingdom.getPropertyValue(flag));
+				}
 			}
 			// Kingdom Membership
 			kingdomSection.set("open", kingdom.isOpen());
@@ -4505,8 +4507,10 @@ public class KingdomManager implements KonquestKingdomManager, Timeable {
 				}
 				// Town Properties
 				ConfigurationSection townPropertiesSection = townInstanceSection.createSection("properties");
-				for(KonPropertyFlag flag : town.getAllProperties().keySet()) {
-					townPropertiesSection.set(flag.toString(), town.getAllProperties().get(flag));
+				for(KonPropertyFlag flag : KonPropertyFlag.values()) {
+					if(town.hasPropertyValue(flag)) {
+						townPropertiesSection.set(flag.toString(), town.getPropertyValue(flag));
+					}
 				}
             	townInstanceSection.set("world", town.getWorld().getName());
             	townInstanceSection.set("base", town.getMonument().getBaseY());

--- a/core/src/main/java/com/github/rumsfield/konquest/manager/RuinManager.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/manager/RuinManager.java
@@ -6,6 +6,7 @@ import com.github.rumsfield.konquest.api.manager.KonquestRuinManager;
 import com.github.rumsfield.konquest.api.model.KonquestRuin;
 import com.github.rumsfield.konquest.model.KonKingdom;
 import com.github.rumsfield.konquest.model.KonPlayer;
+import com.github.rumsfield.konquest.model.KonPropertyFlag;
 import com.github.rumsfield.konquest.model.KonRuin;
 import com.github.rumsfield.konquest.utility.ChatUtil;
 import com.github.rumsfield.konquest.utility.CorePath;
@@ -226,6 +227,20 @@ public class RuinManager implements KonquestRuinManager {
 	                		ruin.addSpawnLocation(loc);
 	            		}
 	                	konquest.getTerritoryManager().addAllTerritory(world,ruin.getChunkList());
+						// Set properties
+						ConfigurationSection ruinPropertiesSection = ruinSection.getConfigurationSection("properties");
+						if(ruinPropertiesSection != null) {
+							for (String propertyName : ruinPropertiesSection.getKeys(false)) {
+								boolean value = ruinPropertiesSection.getBoolean(propertyName);
+								KonPropertyFlag property = KonPropertyFlag.getFlag(propertyName);
+								boolean status = ruin.setPropertyValue(property, value);
+								if (!status) {
+									ChatUtil.printDebug("Failed to set invalid property " + propertyName + " to Ruin " + ruinName);
+								}
+							}
+						}
+						// Update title
+						ruin.updateBarTitle();
 	        		} else {
 	        			String message = "Could not load ruin "+ruinName+", ruins.yml may be corrupted and needs to be deleted.";
 	            		ChatUtil.printConsoleError(message);
@@ -263,6 +278,13 @@ public class RuinManager implements KonquestRuinManager {
 			ruinSection.set("chunks", konquest.formatPointsToString(ruin.getChunkList().keySet()));
 			ruinSection.set("criticals", konquest.formatLocationsToString(ruin.getCriticalLocations()));
 			ruinSection.set("spawns", konquest.formatLocationsToString(ruin.getSpawnLocations()));
+			// Properties
+			ConfigurationSection ruinPropertiesSection = ruinSection.createSection("properties");
+			for(KonPropertyFlag flag : KonPropertyFlag.values()) {
+				if(ruin.hasPropertyValue(flag)) {
+					ruinPropertiesSection.set(flag.toString(), ruin.getPropertyValue(flag));
+				}
+			}
 		}
 	}
 	

--- a/core/src/main/java/com/github/rumsfield/konquest/manager/SanctuaryManager.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/manager/SanctuaryManager.java
@@ -589,15 +589,18 @@ public class SanctuaryManager {
 	        			konquest.getTerritoryManager().addAllTerritory(sanctuaryWorld,sanctuary.getChunkList());
 	        			// Set properties
 	        			ConfigurationSection sanctuaryPropertiesSection = sanctuarySection.getConfigurationSection("properties");
-						assert sanctuaryPropertiesSection != null;
-	        			for(String propertyName : sanctuaryPropertiesSection.getKeys(false)) {
-	        				boolean value = sanctuaryPropertiesSection.getBoolean(propertyName);
-	        				KonPropertyFlag property = KonPropertyFlag.getFlag(propertyName);
-	        				boolean status = sanctuary.setPropertyValue(property, value);
-	        				if(!status) {
-	        					ChatUtil.printDebug("Failed to set invalid property "+propertyName+" to Sanctuary "+sanctuaryName);
-	        				}
-	        			}
+						if(sanctuaryPropertiesSection != null) {
+							for (String propertyName : sanctuaryPropertiesSection.getKeys(false)) {
+								boolean value = sanctuaryPropertiesSection.getBoolean(propertyName);
+								KonPropertyFlag property = KonPropertyFlag.getFlag(propertyName);
+								boolean status = sanctuary.setPropertyValue(property, value);
+								if (!status) {
+									ChatUtil.printDebug("Failed to set invalid property " + propertyName + " to Sanctuary " + sanctuaryName);
+								}
+							}
+						}
+						// Update title
+						sanctuary.updateBarTitle();
 	        			// Load Monument Templates
 	        			ConfigurationSection sanctuaryMonumentsSection = sanctuarySection.getConfigurationSection("monuments");
 						assert sanctuaryMonumentsSection != null;
@@ -713,8 +716,10 @@ public class SanctuaryManager {
 			sanctuarySection.set("chunks", konquest.formatPointsToString(sanctuary.getChunkList().keySet()));
 			// Properties
 			ConfigurationSection sanctuaryPropertiesSection = sanctuarySection.createSection("properties");
-			for(KonPropertyFlag flag : sanctuary.getAllProperties().keySet()) {
-				sanctuaryPropertiesSection.set(flag.toString(), sanctuary.getAllProperties().get(flag));
+			for(KonPropertyFlag flag : KonPropertyFlag.values()) {
+				if(sanctuary.hasPropertyValue(flag)) {
+					sanctuaryPropertiesSection.set(flag.toString(), sanctuary.getPropertyValue(flag));
+				}
 			}
 			// Monuments
 			// Any template in memory, valid or invalid, gets saved to data file.

--- a/core/src/main/java/com/github/rumsfield/konquest/model/KonPropertyFlag.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/model/KonPropertyFlag.java
@@ -21,6 +21,7 @@ public enum KonPropertyFlag {
 	ENTER			(MessagePath.PROPERTIES_ENTER_NAME.getMessage(), 	MessagePath.PROPERTIES_ENTER.getMessage()),
 	EXIT			(MessagePath.PROPERTIES_EXIT_NAME.getMessage(), 	MessagePath.PROPERTIES_EXIT.getMessage()),
 	SHOP			(MessagePath.PROPERTIES_SHOP_NAME.getMessage(), 	MessagePath.PROPERTIES_SHOP.getMessage()),
+	ARENA		    (MessagePath.PROPERTIES_ARENA_NAME.getMessage(), 	MessagePath.PROPERTIES_ARENA.getMessage()),
 
 	// Properties specifically for towns/capitals
 	CAPTURE			(MessagePath.PROPERTIES_CAPTURE_NAME.getMessage(), 	MessagePath.PROPERTIES_CAPTURE.getMessage()),

--- a/core/src/main/java/com/github/rumsfield/konquest/model/KonRuin.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/model/KonRuin.java
@@ -39,16 +39,16 @@ public class KonRuin extends KonTerritory implements KonquestRuin, KonBarDisplay
 	 */
 	public KonRuin(Location loc, String name, KonKingdom kingdom, Konquest konquest) {
 		super(loc, name, kingdom, konquest);
+		this.properties = new HashMap<>();
+		initProperties();
 		this.spawnTimer = new Timer(this);
 		this.captureTimer = new Timer(this);
 		this.captureCountdownTimer = new Timer(this);
 		this.isCaptureDisabled = false;
-		this.ruinBarAll = Bukkit.getServer().createBossBar(Konquest.neutralColor2+MessagePath.TERRITORY_RUIN.getMessage().trim()+" "+getName(), BarColor.WHITE, BarStyle.SOLID);
+		this.ruinBarAll = Bukkit.getServer().createBossBar(getTitleName(), BarColor.WHITE, BarStyle.SOLID);
 		this.ruinBarAll.setVisible(true);
 		this.criticalLocations = new HashMap<>();
 		this.spawnLocations = new HashMap<>();
-		this.properties = new HashMap<>();
-		initProperties();
 	}
 
 	public static java.util.List<KonPropertyFlag> getProperties() {
@@ -234,7 +234,16 @@ public class KonRuin extends KonTerritory implements KonquestRuin, KonBarDisplay
 
 	@Override
 	public void updateBarTitle() {
-		ruinBarAll.setTitle(Konquest.neutralColor2+MessagePath.TERRITORY_RUIN.getMessage().trim()+" "+getName());
+		ruinBarAll.setTitle(getTitleName());
+	}
+
+	private String getTitleName() {
+		String title = Konquest.neutralColor2+MessagePath.TERRITORY_RUIN.getMessage().trim()+" "+getName();
+		if(properties.get(KonPropertyFlag.ARENA)) {
+			// Arena property is true
+			title = title+" - "+ChatColor.RED+MessagePath.PROPERTIES_ARENA_NAME.getMessage();
+		}
+		return title;
 	}
 
 	public void updateBarProgress() {

--- a/core/src/main/java/com/github/rumsfield/konquest/model/KonRuin.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/model/KonRuin.java
@@ -53,6 +53,7 @@ public class KonRuin extends KonTerritory implements KonquestRuin, KonBarDisplay
 
 	public static java.util.List<KonPropertyFlag> getProperties() {
 		java.util.List<KonPropertyFlag> result = new ArrayList<>();
+		result.add(KonPropertyFlag.ARENA);
 		result.add(KonPropertyFlag.PVP);
 		result.add(KonPropertyFlag.PVE);
 		result.add(KonPropertyFlag.USE);

--- a/core/src/main/java/com/github/rumsfield/konquest/model/KonSanctuary.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/model/KonSanctuary.java
@@ -6,6 +6,7 @@ import com.github.rumsfield.konquest.api.model.KonquestTerritoryType;
 import com.github.rumsfield.konquest.utility.*;
 import com.github.rumsfield.konquest.utility.Timer;
 import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.boss.BarColor;
@@ -25,10 +26,10 @@ public class KonSanctuary extends KonTerritory implements KonquestSanctuary, Kon
 	
 	public KonSanctuary(Location loc, String name, KonKingdom kingdom, Konquest konquest) {
 		super(loc, name, kingdom, konquest);
-		this.sanctuaryBarAll = Bukkit.getServer().createBossBar(Konquest.neutralColor2+MessagePath.TERRITORY_SANCTUARY.getMessage().trim()+" "+getName(), BarColor.WHITE, BarStyle.SEGMENTED_20);
-		this.sanctuaryBarAll.setVisible(true);
 		this.properties = new HashMap<>();
 		initProperties();
+		this.sanctuaryBarAll = Bukkit.getServer().createBossBar(getTitleName(), BarColor.WHITE, BarStyle.SEGMENTED_20);
+		this.sanctuaryBarAll.setVisible(true);
 		this.templates = new HashMap<>();
 		this.templateBlankingTimers = new HashMap<>();
 	}
@@ -98,7 +99,16 @@ public class KonSanctuary extends KonTerritory implements KonquestSanctuary, Kon
 
 	@Override
 	public void updateBarTitle() {
-		sanctuaryBarAll.setTitle(Konquest.neutralColor2+MessagePath.TERRITORY_SANCTUARY.getMessage().trim()+" "+getName());
+		sanctuaryBarAll.setTitle(getTitleName());
+	}
+
+	private String getTitleName() {
+		String title = Konquest.neutralColor2+MessagePath.TERRITORY_SANCTUARY.getMessage().trim()+" "+getName();
+		if(properties.get(KonPropertyFlag.ARENA)) {
+			// Arena property is true
+			title = title+" - "+ChatColor.RED+MessagePath.PROPERTIES_ARENA_NAME.getMessage();
+		}
+		return title;
 	}
 
 	@Override

--- a/core/src/main/java/com/github/rumsfield/konquest/model/KonSanctuary.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/model/KonSanctuary.java
@@ -36,6 +36,7 @@ public class KonSanctuary extends KonTerritory implements KonquestSanctuary, Kon
 	public static java.util.List<KonPropertyFlag> getProperties() {
 		java.util.List<KonPropertyFlag> result = new ArrayList<>();
 		result.add(KonPropertyFlag.TRAVEL);
+		result.add(KonPropertyFlag.ARENA);
 		result.add(KonPropertyFlag.PVP);
 		result.add(KonPropertyFlag.PVE);
 		result.add(KonPropertyFlag.BUILD);

--- a/core/src/main/java/com/github/rumsfield/konquest/model/KonTown.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/model/KonTown.java
@@ -129,6 +129,7 @@ public class KonTown extends KonTerritory implements KonquestTown, KonBarDisplay
 		result.add(KonPropertyFlag.UPGRADE);
 		result.add(KonPropertyFlag.PLOTS);
 		result.add(KonPropertyFlag.TRAVEL);
+		result.add(KonPropertyFlag.ARENA);
 		result.add(KonPropertyFlag.PVP);
 		result.add(KonPropertyFlag.PVE);
 		result.add(KonPropertyFlag.BUILD);

--- a/core/src/main/java/com/github/rumsfield/konquest/model/KonTown.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/model/KonTown.java
@@ -129,7 +129,6 @@ public class KonTown extends KonTerritory implements KonquestTown, KonBarDisplay
 		result.add(KonPropertyFlag.UPGRADE);
 		result.add(KonPropertyFlag.PLOTS);
 		result.add(KonPropertyFlag.TRAVEL);
-		result.add(KonPropertyFlag.ARENA);
 		result.add(KonPropertyFlag.PVP);
 		result.add(KonPropertyFlag.PVE);
 		result.add(KonPropertyFlag.BUILD);

--- a/core/src/main/java/com/github/rumsfield/konquest/utility/MessagePath.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/utility/MessagePath.java
@@ -899,6 +899,7 @@ public enum MessagePath {
 	PROPERTIES_DEMOTE							(0, "properties.demote"),
 	PROPERTIES_TRANSFER							(0, "properties.transfer"),
 	PROPERTIES_SHOP  							(0, "properties.shop"),
+	PROPERTIES_ARENA  							(0, "properties.arena"),
 
 	PROPERTIES_TRAVEL_NAME						(0, "properties.travel-name"),
 	PROPERTIES_PVP_NAME							(0, "properties.pvp-name"),
@@ -923,6 +924,7 @@ public enum MessagePath {
 	PROPERTIES_DEMOTE_NAME						(0, "properties.demote-name"),
 	PROPERTIES_TRANSFER_NAME					(0, "properties.transfer-name"),
 	PROPERTIES_SHOP_NAME						(0, "properties.shop-name"),
+	PROPERTIES_ARENA_NAME						(0, "properties.arena-name"),
 
 	NULL_MESSAGE	(0,"");
 	

--- a/core/src/main/resources/lang/english.yml
+++ b/core/src/main/resources/lang/english.yml
@@ -1024,3 +1024,5 @@ properties:
   transfer: "Allow ownership transfer"
   shop-name: "Shop"
   shop: "Allow players to create shops"
+  arena-name: "Arena"
+  arena: "Allow any players to fight each other"

--- a/core/src/main/resources/properties.yml
+++ b/core/src/main/resources/properties.yml
@@ -16,6 +16,7 @@
 #	ENTER			Allow players to enter
 #	EXIT			Allow players to exit
 #   SHOP            Allow players to create shops
+#   ARENA           Allow any players to fight each other
 # 
 # Properties specifically for towns/capitals
 #	CAPTURE			Allow this town to be captured
@@ -60,6 +61,7 @@ properties:
     mobs: false
     portals: true
     shop: false
+    arena: false
   ruins:
     enter: true
     exit: true
@@ -68,6 +70,7 @@ properties:
     use: true
     chest: true
     portals: true
+    arena: false
   towns:
     capture: true
     claim: true


### PR DESCRIPTION
# Konquest Pull Request

Closes #151

## Summary
Adds the `ARENA` property to Sanctuaries and Ruins, as well as the `konquest-arena` flag for WorldGuard region integration. Fixes Ruins saving properties to data files and loading properties on server startup. Updates title bar display of Sanctuaries and Ruins to include "- Arena" when the `ARENA` property is true.

Updates player damage listener to ignore protection checks when either the victim is inside of a Sanctuary or Ruin with the `ARENA` property set to true, or the victim is inside of a WorldGuard region with the `konquest-arena` flag set to allow.

## Checklist
- [x] I have merged the latest `develop` commit into this branch and resolved any conflicts.
- [x] I have tested this branch and it is working as intended.
- [x] This Pull Request is ready for review and merging.