### PR TITLE
Updated API version and team packet error checking #171

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -34,7 +34,7 @@ repositories{
 }
 
 dependencies{
-    compileOnly("org.spigotmc:spigot-api:1.20.2-R0.1-SNAPSHOT")
+    compileOnly("org.spigotmc:spigot-api:1.20.4-R0.1-SNAPSHOT")
     compileOnly("org.spigotmc:spigot-api:1.16.5-R0.1-SNAPSHOT")
     compileOnly("org.spigotmc:spigot-1.17.1-R0.1-SNAPSHOT-remapped")
     compileOnly("org.spigotmc:spigot-1.16.5-R0.1-SNAPSHOT")

--- a/core/src/main/java/com/github/rumsfield/konquest/Konquest.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/Konquest.java
@@ -236,6 +236,7 @@ public class Konquest implements KonquestAPI, Timeable {
 				case "v1_19_R3":
 				case "v1_20_R1":
 				case "v1_20_R2":
+				case "v1_20_R3":
 					if(isProtocolLibEnabled) { versionHandler = new Handler_1_19_R1(); }
 	    			break;
 	    		default:
@@ -1354,7 +1355,8 @@ public class Konquest implements KonquestAPI, Timeable {
 					break;
 			}
     		// Send appropriate team packet to online player
-    		versionHandler.sendPlayerTeamPacket(onlinePlayer.getBukkitPlayer(), Collections.singletonList(player.getBukkitPlayer().getName()), onlinePacketTeam);
+			boolean status = versionHandler.sendPlayerTeamPacket(onlinePlayer.getBukkitPlayer(), Collections.singletonList(player.getBukkitPlayer().getName()), onlinePacketTeam);
+			if(!status) ChatUtil.printConsoleError("Failed to send Team Update packet, make sure ProtocolLib is updated and works for this Minecraft version.");
     	}
     	// Send packets to player
     	if(!barbarianNames.isEmpty()) {

--- a/core/src/main/java/com/github/rumsfield/konquest/nms/Handler_1_16_R3.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/nms/Handler_1_16_R3.java
@@ -45,15 +45,15 @@ public class Handler_1_16_R3 implements VersionHandler {
 	}
 	
 	@Override
-	public void sendPlayerTeamPacket(Player player, List<String> teamNames, Team team) {
+	public boolean sendPlayerTeamPacket(Player player, List<String> teamNames, Team team) {
 		// Create team packet
 		boolean fieldNameSuccess = false;
 		boolean fieldModeSuccess = false;
 		boolean fieldPlayersSuccess = false;
 		
-		PacketContainer teamPacket = new PacketContainer(PacketType.Play.Server.SCOREBOARD_TEAM);
 		try {
-			
+			PacketContainer teamPacket = new PacketContainer(PacketType.Play.Server.SCOREBOARD_TEAM);
+
 			teamPacket.getStrings().write(0, team.getName());
 			fieldNameSuccess = true;
 
@@ -64,9 +64,10 @@ public class Handler_1_16_R3 implements VersionHandler {
 			fieldPlayersSuccess = true;
 
 			ProtocolLibrary.getProtocolManager().sendServerPacket(player, teamPacket);
-
-		} catch(FieldAccessException e) {
+			return true;
+		} catch(Exception e) {
 			ChatUtil.printDebug("Failed to create team packet for player "+player.getName()+", field status is "+fieldNameSuccess+","+fieldModeSuccess+","+fieldPlayersSuccess+": "+e.getMessage());
+			return false;
 		}
 	}
 }

--- a/core/src/main/java/com/github/rumsfield/konquest/nms/Handler_1_17_R1.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/nms/Handler_1_17_R1.java
@@ -45,15 +45,15 @@ public class Handler_1_17_R1 implements VersionHandler {
 	}
 
 	@Override
-	public void sendPlayerTeamPacket(Player player, List<String> teamNames, Team team) {
+	public boolean sendPlayerTeamPacket(Player player, List<String> teamNames, Team team) {
 		// Create team packet
 		boolean fieldNameSuccess = false;
 		boolean fieldModeSuccess = false;
 		boolean fieldPlayersSuccess = false;
 		
-		PacketContainer teamPacket = new PacketContainer(PacketType.Play.Server.SCOREBOARD_TEAM);
 		try {
-			
+			PacketContainer teamPacket = new PacketContainer(PacketType.Play.Server.SCOREBOARD_TEAM);
+
 			teamPacket.getStrings().write(0, team.getName());
 			fieldNameSuccess = true;
 
@@ -64,9 +64,10 @@ public class Handler_1_17_R1 implements VersionHandler {
 			fieldPlayersSuccess = true;
 
 			ProtocolLibrary.getProtocolManager().sendServerPacket(player, teamPacket);
-
-		} catch(FieldAccessException e) {
+			return true;
+		} catch(Exception e) {
 			ChatUtil.printDebug("Failed to create team packet for player "+player.getName()+", field status is "+fieldNameSuccess+","+fieldModeSuccess+","+fieldPlayersSuccess+": "+e.getMessage());
+			return false;
 		}
 	}
 }

--- a/core/src/main/java/com/github/rumsfield/konquest/nms/Handler_1_18_R1.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/nms/Handler_1_18_R1.java
@@ -45,15 +45,15 @@ public class Handler_1_18_R1 implements VersionHandler {
 	}
 	
 	@Override
-	public void sendPlayerTeamPacket(Player player, List<String> teamNames, Team team) {
+	public boolean sendPlayerTeamPacket(Player player, List<String> teamNames, Team team) {
 		// Create team packet
 		boolean fieldNameSuccess = false;
 		boolean fieldModeSuccess = false;
 		boolean fieldPlayersSuccess = false;
 		
-		PacketContainer teamPacket = new PacketContainer(PacketType.Play.Server.SCOREBOARD_TEAM);
 		try {
-			
+			PacketContainer teamPacket = new PacketContainer(PacketType.Play.Server.SCOREBOARD_TEAM);
+
 			teamPacket.getStrings().write(0, team.getName());
 			fieldNameSuccess = true;
 
@@ -64,9 +64,10 @@ public class Handler_1_18_R1 implements VersionHandler {
 			fieldPlayersSuccess = true;
 
 			ProtocolLibrary.getProtocolManager().sendServerPacket(player, teamPacket);
-
-		} catch(FieldAccessException e) {
+			return true;
+		} catch(Exception e) {
 			ChatUtil.printDebug("Failed to create team packet for player "+player.getName()+", field status is "+fieldNameSuccess+","+fieldModeSuccess+","+fieldPlayersSuccess+": "+e.getMessage());
+			return false;
 		}
 	}
 }

--- a/core/src/main/java/com/github/rumsfield/konquest/nms/Handler_1_18_R2.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/nms/Handler_1_18_R2.java
@@ -45,15 +45,15 @@ public class Handler_1_18_R2 implements VersionHandler {
 	}
 	
 	@Override
-	public void sendPlayerTeamPacket(Player player, List<String> teamNames, Team team) {
+	public boolean sendPlayerTeamPacket(Player player, List<String> teamNames, Team team) {
 		// Create team packet
 		boolean fieldNameSuccess = false;
 		boolean fieldModeSuccess = false;
 		boolean fieldPlayersSuccess = false;
 		
-		PacketContainer teamPacket = new PacketContainer(PacketType.Play.Server.SCOREBOARD_TEAM);
 		try {
-			
+			PacketContainer teamPacket = new PacketContainer(PacketType.Play.Server.SCOREBOARD_TEAM);
+
 			teamPacket.getStrings().write(0, team.getName());
 			fieldNameSuccess = true;
 
@@ -64,9 +64,10 @@ public class Handler_1_18_R2 implements VersionHandler {
 			fieldPlayersSuccess = true;
 
 			ProtocolLibrary.getProtocolManager().sendServerPacket(player, teamPacket);
-
-		} catch(FieldAccessException e) {
+			return true;
+		} catch(Exception e) {
 			ChatUtil.printDebug("Failed to create team packet for player "+player.getName()+", field status is "+fieldNameSuccess+","+fieldModeSuccess+","+fieldPlayersSuccess+": "+e.getMessage());
+			return false;
 		}
 	}
 }

--- a/core/src/main/java/com/github/rumsfield/konquest/nms/Handler_1_19_R1.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/nms/Handler_1_19_R1.java
@@ -45,14 +45,14 @@ public class Handler_1_19_R1 implements VersionHandler {
 	}
 	
 	@Override
-	public void sendPlayerTeamPacket(Player player, List<String> teamNames, Team team) {
+	public boolean sendPlayerTeamPacket(Player player, List<String> teamNames, Team team) {
 		// Create team packet
 		boolean fieldNameSuccess = false;
 		boolean fieldModeSuccess = false;
 		boolean fieldPlayersSuccess = false;
-		
-		PacketContainer teamPacket = new PacketContainer(PacketType.Play.Server.SCOREBOARD_TEAM);
+
 		try {
+			PacketContainer teamPacket = new PacketContainer(PacketType.Play.Server.SCOREBOARD_TEAM);
 			
 			teamPacket.getStrings().write(0, team.getName());
 			fieldNameSuccess = true;
@@ -64,9 +64,11 @@ public class Handler_1_19_R1 implements VersionHandler {
 			fieldPlayersSuccess = true;
 
 			ProtocolLibrary.getProtocolManager().sendServerPacket(player, teamPacket);
+			return true;
 
-		} catch(FieldAccessException e) {
+		} catch(Exception e) {
 			ChatUtil.printDebug("Failed to create team packet for player "+player.getName()+", field status is "+fieldNameSuccess+","+fieldModeSuccess+","+fieldPlayersSuccess+": "+e.getMessage());
+			return false;
 		}
 	}
 }

--- a/core/src/main/java/com/github/rumsfield/konquest/nms/VersionHandler.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/nms/VersionHandler.java
@@ -10,5 +10,5 @@ public interface VersionHandler {
 
 	void applyTradeDiscount(double discountPercent, boolean isStack, MerchantInventory merchantInventory);
 	
-	void sendPlayerTeamPacket(Player player, List<String> teamNames, Team team);
+	boolean sendPlayerTeamPacket(Player player, List<String> teamNames, Team team);
 }


### PR DESCRIPTION
# Konquest Pull Request

Closes #171

## Summary
Adds support for Minecraft 1.20.4. Improves error checking for Team Update packets using ProtocolLib.

## Checklist
- [x] I have merged the latest `develop` commit into this branch and resolved any conflicts.
- [x] I have tested this branch and it is working as intended.
- [x] This Pull Request is ready for review and merging.