### PR TITLE
Added travel cancel on damage #172

### DIFF
--- a/core/src/main/java/com/github/rumsfield/konquest/listener/EntityListener.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/listener/EntityListener.java
@@ -421,6 +421,21 @@ public class EntityListener implements Listener {
 			event.setCancelled(true);
 		}
 	}
+
+	@EventHandler(priority = EventPriority.MONITOR)
+	public void onPlayerDamage(EntityDamageEvent event) {
+		if(konquest.isWorldIgnored(event.getEntity().getWorld())) return;
+		if(!(event.getEntity() instanceof Player)) return;
+		Player damagePlayer = (Player)event.getEntity();
+		// Try to cancel any travel warmup
+		boolean doCancelTravelOnDamage = konquest.getCore().getBoolean(CorePath.TRAVEL_CANCEL_ON_DAMAGE.getPath(), false);
+		if(doCancelTravelOnDamage) {
+			boolean status = konquest.getTravelManager().cancelTravel(damagePlayer);
+			if(status) {
+				ChatUtil.sendError(damagePlayer, MessagePath.COMMAND_TRAVEL_ERROR_DAMAGED.getMessage());
+			}
+		}
+	}
 	
 	@EventHandler(priority = EventPriority.NORMAL)
     public void onEntityDamage(EntityDamageEvent event) {
@@ -437,7 +452,6 @@ public class EntityListener implements Listener {
 				event.setCancelled(true);
 			}
 		}
-
 	}
 
 	@EventHandler(priority = EventPriority.HIGH)

--- a/core/src/main/java/com/github/rumsfield/konquest/utility/CorePath.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/utility/CorePath.java
@@ -72,7 +72,8 @@ public enum CorePath {
 	TRAVEL_WILD_CENTER_Z                                  ("core.travel.wild_center_z"),
 	TRAVEL_WARMUP                                         ("core.travel.warmup"),
 	TRAVEL_CANCEL_ON_MOVE                                 ("core.travel.cancel_on_move"),
-	
+	TRAVEL_CANCEL_ON_DAMAGE                               ("core.travel.cancel_on_damage"),
+
 	KINGDOMS_CAPITAL_SUFFIX                               ("core.kingdoms.capital_suffix"),
 	KINGDOMS_CAPITAL_PREFIX_SWAP                          ("core.kingdoms.capital_prefix_swap"),
 	KINGDOMS_CAPITAL_RESPAWN                              ("core.kingdoms.capital_respawn"),

--- a/core/src/main/java/com/github/rumsfield/konquest/utility/MessagePath.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/utility/MessagePath.java
@@ -644,6 +644,7 @@ public enum MessagePath {
 	COMMAND_TRAVEL_ERROR_NO_TOWN                (0, "command.travel.error.no-town"),
 	COMMAND_TRAVEL_ERROR_COOLDOWN               (2, "command.travel.error.cooldown"),
 	COMMAND_TRAVEL_ERROR_CANCELED               (0, "command.travel.error.canceled"),
+	COMMAND_TRAVEL_ERROR_DAMAGED                (0, "command.travel.error.damaged"),
 	COMMAND_TRAVEL_ERROR_DISABLED               (0, "command.travel.error.disabled"),
 	COMMAND_UNCLAIM_NOTICE_SUCCESS              (2, "command.unclaim.notice.success"),
 	COMMAND_UNCLAIM_NOTICE_FAIL_AUTO            (0, "command.unclaim.notice.fail-auto"),

--- a/core/src/main/resources/core.yml
+++ b/core/src/main/resources/core.yml
@@ -248,6 +248,9 @@ core:
     
     # Whether to cancel a travel warmup if the player moves to another block (true/false)
     cancel_on_move: true
+
+    # Whether to cancel a travel warmup if the player takes any damage (true/false)
+    cancel_on_damage: true
     
   # //// CORE.KINGDOMS \\\\
   kingdoms:

--- a/core/src/main/resources/lang/english.yml
+++ b/core/src/main/resources/lang/english.yml
@@ -731,6 +731,7 @@ command:
       no-town: "That town does not exist in your Kingdom."
       cooldown: "You must wait %s before traveling to %s."
       canceled: "Your travel was canceled by movement."
+      damaged: "Your travel was canceled by damage."
       disabled: "Travel to that territory is disabled."
   unclaim:
     notice:


### PR DESCRIPTION
# Konquest Pull Request

Closes #172

## Summary
Adds a core.yml option to cancel travel warmups when the player takes any damage.

## Checklist
- [x] I have merged the latest `develop` commit into this branch and resolved any conflicts.
- [x] I have tested this branch and it is working as intended.
- [x] This Pull Request is ready for review and merging.