### PR TITLE
Feature/67 jitpack package repo

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -27,6 +27,9 @@ tasks {
 java{
     sourceCompatibility = JavaVersion.VERSION_11
     targetCompatibility = JavaVersion.VERSION_11
+
+    withJavadocJar()
+    withSourcesJar()
 }
 
 publishing {

--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     java
     id("com.github.johnrengelman.shadow") version "7.1.2"
+    `maven-publish`
 }
 
 dependencies{
@@ -26,4 +27,15 @@ tasks {
 java{
     sourceCompatibility = JavaVersion.VERSION_1_8
     targetCompatibility = JavaVersion.VERSION_1_8
+}
+
+publishing {
+    publications {
+        create<MavenPublication>("maven") {
+            groupId = project.group.toString()
+            artifactId = rootProject.name+"-"+project.name
+            version = project.version.toString()
+            from(components["java"])
+        }
+    }
 }

--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -38,4 +38,7 @@ publishing {
             from(components["java"])
         }
     }
+    repositories{
+        mavenLocal()
+    }
 }

--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     java
-    id("com.github.johnrengelman.shadow") version "7.1.2"
     `maven-publish`
 }
 
@@ -9,7 +8,8 @@ dependencies{
 }
 
 tasks {
-    shadowJar {
+
+    jar{
         archiveBaseName.set(rootProject.name+"-"+project.name)
         archiveClassifier.set("")
         destinationDirectory.set(file("$rootDir/build/libs"))
@@ -32,10 +32,11 @@ java{
 publishing {
     publications {
         create<MavenPublication>("maven") {
+            from(components["java"])
+
             groupId = project.group.toString()
             artifactId = rootProject.name+"-"+project.name
             version = project.version.toString()
-            from(components["java"])
         }
     }
     repositories{

--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -25,8 +25,8 @@ tasks {
 }
 
 java{
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
 }
 
 publishing {

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -41,7 +41,7 @@ dependencies{
     compileOnly("com.comphenix.protocol:ProtocolLib:5.0.0")
     compileOnly("org.maxgamer:QuickShop:5.1.2.2-SNAPSHOT")
     compileOnly("com.acrobot.chestshop:chestshop:3.12")
-    compileOnly("org.dynmap:dynmap:3.4-beta-2-spigot")
+    compileOnly("org.dynmap:Dynmap:3.4-beta-2-spigot")
     compileOnly("com.github.MilkBowl:VaultAPI:1.7.1")
     compileOnly("com.discordsrv:discordsrv:1.27.0")
     compileOnly("me.clip:placeholderapi:2.11.2")

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     java
     id("com.github.johnrengelman.shadow") version "7.1.2"
+    `maven-publish`
 }
 
 repositories{
@@ -76,4 +77,18 @@ tasks {
 java{
     sourceCompatibility = JavaVersion.VERSION_11
     targetCompatibility = JavaVersion.VERSION_11
+}
+
+publishing {
+    publications {
+        create<MavenPublication>("maven") {
+            groupId = project.group.toString()
+            artifactId = rootProject.name+"-"+project.name
+            version = project.version.toString()
+            from(components["java"])
+        }
+    }
+    repositories{
+        mavenLocal()
+    }
 }

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -78,17 +78,3 @@ java{
     sourceCompatibility = JavaVersion.VERSION_11
     targetCompatibility = JavaVersion.VERSION_11
 }
-
-publishing {
-    publications {
-        create<MavenPublication>("maven") {
-            groupId = project.group.toString()
-            artifactId = rootProject.name+"-"+project.name
-            version = project.version.toString()
-            from(components["java"])
-        }
-    }
-    repositories{
-        mavenLocal()
-    }
-}

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,2 +1,2 @@
 jdk:
-  - openjdk11
+  - openjdk17

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,2 @@
+jdk:
+  - openjdk11


### PR DESCRIPTION
# Konquest Pull Request

Closes #38 #67

## Summary
allow JitPack to be a maven repository for the plugin api

## Change Details
- added jitpack.yml to tell Jitpack to use Java 11
- update API module to use Java 11
- add maven publication in API module for JitPack to use
- remove shadowJar from API module (not needed, and conflicted with maven publication)
- fixed "dynmap" to "Dynmap" in the core module

## Checklist
- [x] I have merged the latest `develop` commit into this branch and resolved any conflicts.
- [x] I have tested this branch and it is working as intended.
- [x] This Pull Request is ready for review and merging.