### PR TITLE
Added alphanumeric checks, replaced towns placeholders #187

### DIFF
--- a/core/src/main/java/com/github/rumsfield/konquest/Konquest.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/Konquest.java
@@ -14,7 +14,7 @@ import com.github.rumsfield.konquest.shop.ShopHandler;
 import com.github.rumsfield.konquest.utility.*;
 import com.github.rumsfield.konquest.utility.Timer;
 import com.google.common.collect.MapMaker;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.bukkit.*;
 import org.bukkit.attribute.Attribute;
 import org.bukkit.block.Block;

--- a/core/src/main/java/com/github/rumsfield/konquest/KonquestPlaceholderExpansion.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/KonquestPlaceholderExpansion.java
@@ -118,20 +118,20 @@ public class KonquestPlaceholderExpansion extends PlaceholderExpansion implement
 	        case "barbarian":
 	        	result = placeholderManager.getBarbarian(player);
 	        	break;
-	        /* %konquest_towns_lord% - comma-separated list of player's lord only towns */
-	        case "towns_lord":
+	        /* %konquest_num_town_lord% - number of player's lord-only towns */
+	        case "num_town_lord":
 	        	result = placeholderManager.getTownsLord(player);
 	        	break;
-	        /* %konquest_towns_knight% - comma-separated list of player's knight only towns */
-	        case "towns_knight":
+	        /* %konquest_num_town_knight% - number of player's knight-only towns */
+	        case "num_town_knight":
 	        	result = placeholderManager.getTownsKnight(player);
 	        	break;
-	        /* %konquest_towns_resident% - comma-separated list of player's resident only towns */
-	        case "towns_resident":
+	        /* %konquest_num_town_resident% - number of player's resident-only towns */
+	        case "num_town_resident":
 	        	result = placeholderManager.getTownsResident(player);
 	        	break;
-	        /* %konquest_towns_all% - comma-separated list of player's all towns */
-	        case "towns_all":
+	        /* %konquest_num_town_all% - number of player's total towns */
+	        case "num_town_all":
 	        	result = placeholderManager.getTownsAll(player);
 	        	break;
 	        /* %konquest_territory% - player's current location territory type */
@@ -320,44 +320,44 @@ public class KonquestPlaceholderExpansion extends PlaceholderExpansion implement
 				break;
 	        default: 
 	        	// Check for kingdom-specific placeholders
-	        	
+
 	        	/* %konquest_players_<kingdom>% */
-	        	if(identifierLower.matches("players_[a-zA-Z0-9_]+")) {
+				if(identifierLower.matches("^players_.+$")) {
 	        		try {
 	        			String kingdomName = identifierLower.substring(8);
 	        			result = placeholderManager.getKingdomPlayers(kingdomName);
 	        		} catch(IndexOutOfBoundsException ignored) {}
 	        		
         		/* %konquest_online_<kingdom>% */
-	        	} else if(identifierLower.matches("online_[a-zA-Z0-9_]+")) {
+	        	} else if(identifierLower.matches("^online_.+$")) {
 	        		try {
 	        			String kingdomName = identifierLower.substring(7);
 	        			result = placeholderManager.getKingdomOnline(kingdomName);
 	        		} catch(IndexOutOfBoundsException ignored) {}
 	        		
         		/* %konquest_towns_<kingdom>% */
-	        	} else if(identifierLower.matches("towns_[a-zA-Z0-9_]+")) {
+	        	} else if(identifierLower.matches("^towns_.+$")) {
 	        		try {
 	        			String kingdomName = identifierLower.substring(6);
 	        			result = placeholderManager.getKingdomTowns(kingdomName);
 	        		} catch(IndexOutOfBoundsException ignored) {}
 	        		
         		/* %konquest_land_<kingdom>% */
-	        	} else if(identifierLower.matches("land_[a-zA-Z0-9_]+")) {
+	        	} else if(identifierLower.matches("^land_.+$")) {
 	        		try {
 	        			String kingdomName = identifierLower.substring(5);
 	        			result = placeholderManager.getKingdomLand(kingdomName);
 	        		} catch(IndexOutOfBoundsException ignored) {}
 	        		
         		/* %konquest_favor_<kingdom>% */
-	        	} else if(identifierLower.matches("favor_[a-zA-Z0-9_]+")) {
+	        	} else if(identifierLower.matches("^favor_.+$")) {
 	        		try {
 	        			String kingdomName = identifierLower.substring(6);
 	        			result = placeholderManager.getKingdomFavor(kingdomName);
 	        		} catch(IndexOutOfBoundsException ignored) {}
 	        		
         		/* %konquest_score_<kingdom>% */
-	        	} else if(identifierLower.matches("score_[a-zA-Z0-9_]+")) {
+	        	} else if(identifierLower.matches("^score_.+$")) {
 	        		try {
 	        			String kingdomName = identifierLower.substring(6);
 	        			result = placeholderManager.getKingdomScore(kingdomName);

--- a/core/src/main/java/com/github/rumsfield/konquest/command/CommandHandler.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/command/CommandHandler.java
@@ -18,6 +18,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import org.apache.commons.lang3.StringUtils;
+
 public class CommandHandler  implements TabExecutor {
 
 	private final Konquest konquest;

--- a/core/src/main/java/com/github/rumsfield/konquest/manager/AccomplishmentManager.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/manager/AccomplishmentManager.java
@@ -7,6 +7,7 @@ import com.github.rumsfield.konquest.model.*;
 import com.github.rumsfield.konquest.utility.ChatUtil;
 import com.github.rumsfield.konquest.utility.CorePath;
 import com.github.rumsfield.konquest.utility.MessagePath;
+import org.apache.commons.lang3.StringUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
@@ -244,7 +245,7 @@ public class AccomplishmentManager {
     	for(String prefixLabel : prefixConfig.getConfigurationSection("prefix").getKeys(false)) {
     		status = true;
     		prefixEntry = prefixConfig.getConfigurationSection("prefix."+prefixLabel);
-    		if(prefixEntry != null && prefixLabel.matches("[A-Za-z0-9_]+")) {
+    		if(prefixEntry != null && StringUtils.isAlphanumeric(prefixLabel.replace("_",""))) {
         		if(prefixEntry.contains("name")) {
         			prefixName = prefixEntry.getString("name","");
         			if(prefixName.isEmpty()) {

--- a/core/src/main/java/com/github/rumsfield/konquest/manager/PlaceholderManager.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/manager/PlaceholderManager.java
@@ -126,68 +126,56 @@ public class PlaceholderManager implements KonquestPlaceholderManager {
 	
 	public String getTownsLord(Player player) {
 		KonOfflinePlayer offlinePlayer = playerManager.getOfflinePlayer(player);
-    	StringBuilder list = new StringBuilder();
+    	int numTowns = 0;
     	if(offlinePlayer != null) {
     		for(KonTown town : offlinePlayer.getKingdom().getTowns()) {
     			if(town.isPlayerLord(offlinePlayer.getOfflineBukkitPlayer())) {
-    				list.append(town.getName()).append(",");
+					numTowns++;
     			}
     		}
-    		if(list.length() > 1) {
-    			list = new StringBuilder(list.substring(0, list.length() - 1));
-			}
     	}
-    	return list.toString();
+    	return ""+numTowns;
 	}
 	
 	public String getTownsKnight(Player player) {
 		KonOfflinePlayer offlinePlayer = playerManager.getOfflinePlayer(player);
-		StringBuilder list = new StringBuilder();
+		int numTowns = 0;
     	if(offlinePlayer != null) {
     		for(KonTown town : offlinePlayer.getKingdom().getTowns()) {
     			if(town.isPlayerKnight(offlinePlayer.getOfflineBukkitPlayer()) &&
     					!town.isPlayerLord(offlinePlayer.getOfflineBukkitPlayer())) {
-    				list.append(town.getName()).append(",");
+					numTowns++;
     			}
     		}
-    		if(list.length() > 1) {
-    			list = new StringBuilder(list.substring(0, list.length() - 1));
-			}
     	}
-    	return list.toString();
+    	return ""+numTowns;
 	}
 	
 	public String getTownsResident(Player player) {
 		KonOfflinePlayer offlinePlayer = playerManager.getOfflinePlayer(player);
-		StringBuilder list = new StringBuilder();
+		int numTowns = 0;
     	if(offlinePlayer != null) {
     		for(KonTown town : offlinePlayer.getKingdom().getTowns()) {
     			if(town.isPlayerResident(offlinePlayer.getOfflineBukkitPlayer()) &&
     					!town.isPlayerKnight(offlinePlayer.getOfflineBukkitPlayer())) {
-    				list.append(town.getName()).append(",");
+					numTowns++;
     			}
     		}
-    		if(list.length() > 1) {
-    			list = new StringBuilder(list.substring(0, list.length() - 1));
-			}
     	}
-    	return list.toString();
+    	return ""+numTowns;
 	}
 	
 	public String getTownsAll(Player player) {
 		KonOfflinePlayer offlinePlayer = playerManager.getOfflinePlayer(player);
-		StringBuilder list = new StringBuilder();
+		int numTowns = 0;
     	if(offlinePlayer != null) {
     		for(KonTown town : offlinePlayer.getKingdom().getTowns()) {
     			if(town.isPlayerResident(offlinePlayer.getOfflineBukkitPlayer())) {
-    				list.append(town.getName()).append(",");
+					numTowns++;
     			}
     		}
-    		if(list.length() > 1) {
-    			list = new StringBuilder(list.substring(0, list.length() - 1));
-			}
     	}
-    	return list.toString();
+    	return ""+numTowns;
 	}
 	
 	public String getTerritory(Player player) {


### PR DESCRIPTION
# Konquest Pull Request

Closes #187

## Summary
Replaced all name matching checks that used only Latin a-zA-z regex with [StringUtils isAlphanumeric](https://commons.apache.org/proper/commons-lang/apidocs/org/apache/commons/lang3/StringUtils.html#isAlphanumeric-java.lang.CharSequence-), which works for all languages. Also reworked some placeholders.

## Change Details
* Instances of String matching for name validation now use StringUtils isAlphanumeric.
* All of the town listing placeholders were changed to instead return the number of towns.
    * towns_lord -> num_town_lord
    * towns_knight -> num_town_knight
    * towns_resident -> num_town_resident
    * towns_all -> num_town_all

## Checklist
- [ ] I have merged the latest `develop` commit into this branch and resolved any conflicts.
- [ ] I have tested this branch and it is working as intended.
- [ ] This Pull Request is ready for review and merging.