### PR TITLE
Feature/185 placeholder webcolor

### DIFF
--- a/core/src/main/java/com/github/rumsfield/konquest/KonquestPlaceholderExpansion.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/KonquestPlaceholderExpansion.java
@@ -393,7 +393,7 @@ public class KonquestPlaceholderExpansion extends PlaceholderExpansion implement
 				break;
 			/* %rel_konquest_kingdom_webcolor% - playerTwo's kingdom web color */
 			case "kingdom_webcolor":
-				result = placeholderManager.getRelationKingdomWebColor(playerOne, playerTwo);
+				result = placeholderManager.getRelationKingdomWebColor(playerTwo);
 				break;
         	default: 
 	        	break;

--- a/core/src/main/java/com/github/rumsfield/konquest/KonquestPlaceholderExpansion.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/KonquestPlaceholderExpansion.java
@@ -391,6 +391,10 @@ public class KonquestPlaceholderExpansion extends PlaceholderExpansion implement
 			case "relation2_color":
 				result = placeholderManager.getRelationSecondaryColor(playerOne, playerTwo);
 				break;
+			/* %rel_konquest_kingdom_webcolor% - playerTwo's kingdom web color */
+			case "kingdom_webcolor":
+				result = placeholderManager.getRelationKingdomWebColor(playerOne, playerTwo);
+				break;
         	default: 
 	        	break;
         }

--- a/core/src/main/java/com/github/rumsfield/konquest/manager/PlaceholderManager.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/manager/PlaceholderManager.java
@@ -334,6 +334,23 @@ public class PlaceholderManager implements KonquestPlaceholderManager {
 		}
 		return result;
 	}
+
+	public String getRelationKingdomWebColor(Player playerOne, Player playerTwo) {
+		String result = "";
+		KonPlayer onlinePlayerTwo = playerManager.getPlayer(playerTwo);
+		if(onlinePlayerTwo != null) {
+			int webColor = onlinePlayerTwo.getKingdom().getWebColor();
+			int webColorHash;
+			if(webColor == -1) {
+				int hash = onlinePlayerTwo.getKingdom().getName().hashCode();
+				webColorHash = hash & 0xFFFFFF;
+			} else {
+				webColorHash = webColor;
+			}
+			result = String.format("#%08X",webColorHash);
+		}
+		return result;
+	}
 	
 	/*
 	 * Top rankings

--- a/core/src/main/java/com/github/rumsfield/konquest/manager/PlaceholderManager.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/manager/PlaceholderManager.java
@@ -335,19 +335,15 @@ public class PlaceholderManager implements KonquestPlaceholderManager {
 		return result;
 	}
 
-	public String getRelationKingdomWebColor(Player playerOne, Player playerTwo) {
+	public String getRelationKingdomWebColor(Player playerTwo) {
 		String result = "";
 		KonPlayer onlinePlayerTwo = playerManager.getPlayer(playerTwo);
 		if(onlinePlayerTwo != null) {
 			int webColor = onlinePlayerTwo.getKingdom().getWebColor();
-			int webColorHash;
 			if(webColor == -1) {
-				int hash = onlinePlayerTwo.getKingdom().getName().hashCode();
-				webColorHash = hash & 0xFFFFFF;
-			} else {
-				webColorHash = webColor;
+				webColor = onlinePlayerTwo.getKingdom().getName().hashCode() & 0xFFFFFF;
 			}
-			result = String.format("#%08X",webColorHash);
+			result = ChatUtil.parseHex(String.format("#%06X",webColor));
 		}
 		return result;
 	}


### PR DESCRIPTION
# Konquest Pull Request

Closes #185

## Summary
Adds new placeholder `rel_konquest_kingdom_webcolor`, which returns the target player's kingdom webcolor as a parsed ChatColor. This will directly color preceding text.

## Checklist
- [x] I have merged the latest `develop` commit into this branch and resolved any conflicts.
- [x] I have tested this branch and it is working as intended.
- [x] This Pull Request is ready for review and merging.