### PR TITLE
Added timer placeholders #178

### DIFF
--- a/core/src/main/java/com/github/rumsfield/konquest/Konquest.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/Konquest.java
@@ -1617,14 +1617,21 @@ public class Konquest implements KonquestAPI, Timeable {
 		int hours = valSeconds % 86400 / 3600;
 		int minutes = valSeconds % 3600 / 60;
 		int seconds = valSeconds % 60;
-		
-		ChatColor nColor = ChatColor.GRAY;
-		String numColor = color;
-		if(valSeconds <= 30) {
-			numColor = ""+ChatColor.DARK_RED;
-		}
+
+		String nColor;
+		String numColor;
 		String result;
 		String format;
+		if(color != null && !color.equals("")) {
+			nColor = ""+ChatColor.GRAY;
+			numColor = color;
+			if(valSeconds <= 30) {
+				numColor = ""+ChatColor.DARK_RED;
+			}
+		} else {
+			nColor = "";
+			numColor = "";
+		}
 		
 		if(days != 0) {
 			format = numColor+"%03d"+nColor+"D:"+numColor+"%02d"+nColor+"H:"+numColor+"%02d"+nColor+"M:"+numColor+"%02d"+nColor+"S";

--- a/core/src/main/java/com/github/rumsfield/konquest/KonquestPlaceholderExpansion.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/KonquestPlaceholderExpansion.java
@@ -106,7 +106,15 @@ public class KonquestPlaceholderExpansion extends PlaceholderExpansion implement
         String result = null;
         String identifierLower = identifier.toLowerCase();
         switch(identifierLower) {
-	        /* %konquest_kingdom% - player's kingdom name */
+			/* %konquest_timer_loot% - Time until monument loot refreshes */
+			case "timer_loot":
+				result = placeholderManager.getTimerLoot(player);
+				break;
+			/* %konquest_timer_payment% - Time until kingdom payment refreshes */
+			case "timer_payment":
+				result = placeholderManager.getTimerPayment(player);
+				break;
+			/* %konquest_kingdom% - player's kingdom name */
         	case "kingdom":
         		result = placeholderManager.getKingdom(player);
 	        	break;

--- a/core/src/main/java/com/github/rumsfield/konquest/manager/KingdomManager.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/manager/KingdomManager.java
@@ -166,6 +166,11 @@ public class KingdomManager implements KonquestKingdomManager, Timeable {
 		discountPercent = Math.max(discountPercent,0);
 		discountPercent = Math.min(discountPercent,100);
 	}
+
+	public String getKingdomPayTime() {
+		String noColor = "";
+		return Konquest.getTimeFormat(payTimer.getTime(), noColor);
+	}
 	
 	public double getCostDiplomacyWar() {
 		return costDiplomacyWar;

--- a/core/src/main/java/com/github/rumsfield/konquest/manager/KingdomManager.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/manager/KingdomManager.java
@@ -151,9 +151,9 @@ public class KingdomManager implements KonquestKingdomManager, Timeable {
 		payPercentOfficer = Math.min(payPercentOfficer, 100);
 		payPercentMaster = Math.max(payPercentMaster, 0);
 		payPercentMaster = Math.min(payPercentMaster, 100);
-		
+
+		payTimer.stopTimer();
 		if(payIntervalSeconds > 0) {
-			payTimer.stopTimer();
 			payTimer.setTime((int)payIntervalSeconds);
 			payTimer.startLoopTimer();
 		}
@@ -169,7 +169,8 @@ public class KingdomManager implements KonquestKingdomManager, Timeable {
 
 	public String getKingdomPayTime() {
 		String noColor = "";
-		return Konquest.getTimeFormat(payTimer.getTime(), noColor);
+		int timerCount = Math.max(payTimer.getTime(),0);
+		return Konquest.getTimeFormat(timerCount, noColor);
 	}
 	
 	public double getCostDiplomacyWar() {

--- a/core/src/main/java/com/github/rumsfield/konquest/manager/LootManager.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/manager/LootManager.java
@@ -266,6 +266,11 @@ public class LootManager implements Timeable{
 	 * Monument Loot
 	 */
 
+	public String getMonumentLootTime() {
+		String noColor = "";
+		return Konquest.getTimeFormat(lootRefreshTimer.getTime(), noColor);
+	}
+
 	/**
 	 * Attempts to fill an inventory with loot
 	 * @param inventory - the inventory to try and fill

--- a/core/src/main/java/com/github/rumsfield/konquest/manager/LootManager.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/manager/LootManager.java
@@ -54,8 +54,8 @@ public class LootManager implements Timeable{
 	public void initialize() {
 		// Parse config for refresh time
 		refreshTimeSeconds = konquest.getCore().getLong(CorePath.MONUMENTS_LOOT_REFRESH.getPath(),0L);
+		lootRefreshTimer.stopTimer();
 		if(refreshTimeSeconds > 0) {
-			lootRefreshTimer.stopTimer();
 			lootRefreshTimer.setTime((int)refreshTimeSeconds);
 			lootRefreshTimer.startLoopTimer();
 		}
@@ -268,7 +268,8 @@ public class LootManager implements Timeable{
 
 	public String getMonumentLootTime() {
 		String noColor = "";
-		return Konquest.getTimeFormat(lootRefreshTimer.getTime(), noColor);
+		int timerCount = Math.max(lootRefreshTimer.getTime(),0);
+		return Konquest.getTimeFormat(timerCount, noColor);
 	}
 
 	/**

--- a/core/src/main/java/com/github/rumsfield/konquest/manager/PlaceholderManager.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/manager/PlaceholderManager.java
@@ -623,5 +623,27 @@ public class PlaceholderManager implements KonquestPlaceholderManager {
 		}
 		return result;
 	}
+
+	/*
+	 * Placeholder Timers
+	 */
+
+	public String getTimerLoot(Player player) {
+		String result = "";
+		KonOfflinePlayer offlinePlayer = playerManager.getOfflinePlayer(player);
+		if(offlinePlayer != null) {
+			result = konquest.getLootManager().getMonumentLootTime();
+		}
+		return result;
+	}
+
+	public String getTimerPayment(Player player) {
+		String result = "";
+		KonOfflinePlayer offlinePlayer = playerManager.getOfflinePlayer(player);
+		if(offlinePlayer != null) {
+			result = konquest.getKingdomManager().getKingdomPayTime();
+		}
+		return result;
+	}
 	
 }


### PR DESCRIPTION
# Konquest Pull Request

Closes #178

## Summary
Added two new placeholders that return formatted countdown timers:
* `konquest_timer_loot` - The time until all monument loot refreshes
* `konquest_timer_payment` - The time until kingdom payments refresh

## Checklist
- [x] I have merged the latest `develop` commit into this branch and resolved any conflicts.
- [x] I have tested this branch and it is working as intended.
- [x] This Pull Request is ready for review and merging.