### PR TITLE
Added color code parsing #192

### DIFF
--- a/core/src/main/java/com/github/rumsfield/konquest/manager/LanguageManager.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/manager/LanguageManager.java
@@ -59,6 +59,8 @@ public class LanguageManager {
 			ChatUtil.printConsoleError("Language file is missing path: "+path);
 			result = "<MISSING>";
 		}
+		// Parse color codes
+		result = ChatUtil.parseHex(result);
 		return result;
 	}
 	


### PR DESCRIPTION
# Konquest Pull Request

Closes #192

## Summary
Added support for color codes in language message files.
* Default ChatColor codes (&2, &b, etc).
* Hex codes (#RRGGBB, etc).

## Checklist
- [x] I have merged the latest `develop` commit into this branch and resolved any conflicts.
- [x] I have tested this branch and it is working as intended.
- [x] This Pull Request is ready for review and merging.