### PR TITLE
Feature/168 chat format rework

### DIFF
--- a/core/src/main/java/com/github/rumsfield/konquest/Konquest.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/Konquest.java
@@ -42,7 +42,8 @@ public class Konquest implements KonquestAPI, Timeable {
 	private static Konquest instance;
 	private static String chatTag;
 	private static String chatMessage;
-	public static final String chatDivider = "\u00BB"; // »
+	private static String chatDivider;
+	//public static final String chatDivider = "\u00BB"; // »
 	public static String friendColor1 		= "§7";
 	public static String friendColor2 		= "§7";
 	public static String enemyColor1 		= "§7";
@@ -121,6 +122,7 @@ public class Konquest implements KonquestAPI, Timeable {
 		instance = this;
 		chatTag = "§7[§6Konquest§7]§f ";
 		chatMessage = "%PREFIX% %KINGDOM% §7| %TITLE% %NAME% %SUFFIX% ";
+		chatDivider = "§8»§r ";
 		
 		databaseThread = new DatabaseThread(this);
 		accomplishmentManager = new AccomplishmentManager(this);
@@ -272,14 +274,20 @@ public class Konquest implements KonquestAPI, Timeable {
 	}
 	
 	private void initManagers() {
-		String configTag = getCore().getString(CorePath.CHAT_TAG.getPath());
+		// Set up chat formats
+		String configTag = getCore().getString(CorePath.CHAT_TAG.getPath(),"");
 		chatTag = ChatUtil.parseHex(configTag);
 		ChatUtil.printDebug("Chat tag is "+chatTag);
 		String configMessage = getCore().getString(CorePath.CHAT_MESSAGE.getPath(),"");
 		if(!configMessage.equals("")) {
+			// Cannot be an empty string
 			chatMessage = ChatUtil.parseHex(configMessage);
 		}
 		ChatUtil.printDebug("Chat message is "+chatMessage);
+		String configDivider = getCore().getString(CorePath.CHAT_DIVIDER.getPath(),"");
+		chatDivider = ChatUtil.parseHex(configDivider);
+		ChatUtil.printDebug("Chat divider is "+chatDivider);
+
 		kingdomManager.loadOptions();
 		integrationManager.initialize();
 		lootManager.initialize();
@@ -1676,7 +1684,11 @@ public class Konquest implements KonquestAPI, Timeable {
     public static String getChatMessage() {
     	return chatMessage;
     }
-    
+
+	public static String getChatDivider() {
+		return chatDivider;
+	}
+
     public static void callKonquestEvent(KonquestEvent event) {
     	if(event != null) {
 	    	try {

--- a/core/src/main/java/com/github/rumsfield/konquest/Konquest.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/Konquest.java
@@ -43,7 +43,6 @@ public class Konquest implements KonquestAPI, Timeable {
 	private static String chatTag;
 	private static String chatMessage;
 	private static String chatDivider;
-	//public static final String chatDivider = "\u00BB"; // »
 	public static String friendColor1 		= "§7";
 	public static String friendColor2 		= "§7";
 	public static String enemyColor1 		= "§7";

--- a/core/src/main/java/com/github/rumsfield/konquest/command/ChatCommand.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/command/ChatCommand.java
@@ -3,6 +3,7 @@ package com.github.rumsfield.konquest.command;
 import com.github.rumsfield.konquest.Konquest;
 import com.github.rumsfield.konquest.model.KonPlayer;
 import com.github.rumsfield.konquest.utility.ChatUtil;
+import com.github.rumsfield.konquest.utility.CorePath;
 import com.github.rumsfield.konquest.utility.MessagePath;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
@@ -29,6 +30,13 @@ public class ChatCommand extends CommandBase {
 			return;
 		}
 		KonPlayer player = getKonquest().getPlayerManager().getPlayer(bukkitPlayer);
+		assert player != null;
+		boolean isChatFormatEnabled = getKonquest().getCore().getBoolean(CorePath.CHAT_ENABLE_FORMAT.getPath(),true);
+		if(!isChatFormatEnabled) {
+			// Chat formatting is disabled, so kingdom chat is unavailable
+			ChatUtil.sendError(bukkitPlayer, MessagePath.GENERIC_ERROR_DISABLED.getMessage());
+			player.setIsGlobalChat(true);
+		}
 		if(!player.isBarbarian()) {
 			if(player.isGlobalChat()) {
 				//ChatUtil.sendNotice(bukkitPlayer, "Chat mode: Kingdom");

--- a/core/src/main/java/com/github/rumsfield/konquest/hook/DiscordSrvHook.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/hook/DiscordSrvHook.java
@@ -122,21 +122,18 @@ public class DiscordSrvHook implements PluginHook {
 			String chatMessage = guildMessage.getContentDisplay();
 			boolean sendMessage = false;
 			if(viewerPlayer.getKingdom().equals(kingdom)) {
-				chatFormat = chatFormat + Konquest.friendColor2+kingdom.getName()+" "+guildUser.getName();
-				messageFormat = ""+ChatColor.GREEN+ChatColor.ITALIC;
+				chatFormat = chatFormat + Konquest.friendColor1+kingdom.getName()+" "+guildUser.getName();
+				messageFormat = ""+ChatColor.RESET+Konquest.friendColor2+ChatColor.ITALIC;
 				sendMessage = true;
 			} else if(viewerPlayer.isAdminBypassActive()) {
 				chatFormat = chatFormat + ChatColor.GOLD+kingdom.getName()+" "+guildUser.getName();
-				messageFormat = ""+ChatColor.GOLD+ChatColor.ITALIC;
+				messageFormat = ""+ChatColor.RESET+ChatColor.GOLD+ChatColor.ITALIC;
 				sendMessage = true;
 			}
-
 			if(sendMessage) {
-				viewerPlayer.getBukkitPlayer().sendMessage(chatFormat + Konquest.chatDivider + ChatColor.RESET + " " + messageFormat + chatMessage);
+				viewerPlayer.getBukkitPlayer().sendMessage(chatFormat + " » " + messageFormat + chatMessage);
 			}
 		}
-
-
 	}
 	
 	// Sends the linked player a direct message

--- a/core/src/main/java/com/github/rumsfield/konquest/listener/PlayerListener.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/listener/PlayerListener.java
@@ -283,15 +283,14 @@ public class PlayerListener implements Listener {
 		event.setCancelled(true);
 
 		// Send messages to players
+		boolean isGlobal = player.isGlobalChat();
 		for(KonPlayer viewerPlayer : playerManager.getPlayersOnline()) {
 			primaryColor = konquest.getDisplayPrimaryColor(viewerPlayer, player);
 			secondaryColor = konquest.getDisplaySecondaryColor(viewerPlayer, player);
-
-			boolean isGlobal = player.isGlobalChat();
-			String messageFormatOverride = "";
+			String kingdomChatFormat = "";
 
 			boolean sendMessage = false;
-			if(player.isGlobalChat()) {
+			if(isGlobal) {
 				// Sender is in global chat mode
 				// All viewers see the message
 				sendMessage = true;
@@ -299,11 +298,15 @@ public class PlayerListener implements Listener {
 				// Sender is in kingdom chat mode
 				if(viewerPlayer.getKingdom().equals(kingdom)) {
 					// Viewer is a friendly kingdom member
-					messageFormatOverride = ""+ChatColor.RESET+Konquest.friendColor2+ChatColor.ITALIC;
+					kingdomChatFormat = ""+ChatColor.GRAY+"["+Konquest.friendColor1+MessagePath.LABEL_KINGDOM.getMessage()+ChatColor.GRAY+"]";
+					kingdomChatFormat += " "+Konquest.friendColor1+playerName+ChatColor.GRAY+" » ";
+					kingdomChatFormat += ""+Konquest.friendColor2+ChatColor.ITALIC;
 					sendMessage = true;
 				} else if(viewerPlayer.isAdminBypassActive()) {
 					// Viewer is an admin in bypass mode
-					messageFormatOverride = ""+ChatColor.RESET+ChatColor.GOLD+ChatColor.ITALIC;
+					kingdomChatFormat = ""+ChatColor.GRAY+"["+ChatColor.GOLD+MessagePath.LABEL_BYPASS.getMessage()+" "+kingdomName+ChatColor.GRAY+"]";
+					kingdomChatFormat += " "+ChatColor.GOLD+playerName+ChatColor.GRAY+" » ";
+					kingdomChatFormat += ""+ChatColor.GOLD+ChatColor.ITALIC;
 					sendMessage = true;
 				}
 			}
@@ -326,20 +329,24 @@ public class PlayerListener implements Listener {
 					// Try to parse relational placeholders
 					parsedFormat = PlaceholderAPI.setRelationalPlaceholders(viewerPlayer.getBukkitPlayer(), bukkitPlayer, parsedFormat);
 				} catch (NoClassDefFoundError ignored) {}
-				// Try to parse color codes in the chat message
-				if(bukkitPlayer.hasPermission("konquest.chatcolor")) {
-					chatMessage = ChatUtil.parseHex(chatMessage);
-				}
 				// Send the chat message
-				viewerPlayer.getBukkitPlayer().sendMessage(parsedFormat + divider + messageFormatOverride + chatMessage);
+				if(isGlobal) {
+					// Try to parse color codes in the chat message
+					if(bukkitPlayer.hasPermission("konquest.chatcolor")) {
+						chatMessage = ChatUtil.parseHex(chatMessage);
+					}
+					viewerPlayer.getBukkitPlayer().sendMessage(parsedFormat + divider + chatMessage);
+				} else {
+					viewerPlayer.getBukkitPlayer().sendMessage(kingdomChatFormat + chatMessage);
+				}
 			}
 		}
 
 		// Send message to console
 		if(player.isGlobalChat()) {
-			ChatUtil.printConsole(ChatColor.GOLD + bukkitPlayer.getName()+": "+ChatColor.DARK_GRAY+event.getMessage());
+			ChatUtil.printConsole(ChatColor.GOLD + playerName+": "+ChatColor.DARK_GRAY+event.getMessage());
 		} else {
-			ChatUtil.printConsole(ChatColor.GOLD + "["+kingdom.getName()+"] "+bukkitPlayer.getName()+": "+ChatColor.DARK_GRAY+event.getMessage());
+			ChatUtil.printConsole(ChatColor.GOLD + "["+kingdomName+"] "+playerName+": "+ChatColor.DARK_GRAY+event.getMessage());
 		}
 
     }

--- a/core/src/main/java/com/github/rumsfield/konquest/listener/PlayerListener.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/listener/PlayerListener.java
@@ -299,7 +299,7 @@ public class PlayerListener implements Listener {
 				// Sender is in kingdom chat mode
 				if(viewerPlayer.getKingdom().equals(kingdom)) {
 					// Viewer is a friendly kingdom member
-					messageFormatOverride = ""+ChatColor.RESET+Konquest.friendColor1+ChatColor.ITALIC;
+					messageFormatOverride = ""+ChatColor.RESET+Konquest.friendColor2+ChatColor.ITALIC;
 					sendMessage = true;
 				} else if(viewerPlayer.isAdminBypassActive()) {
 					// Viewer is an admin in bypass mode

--- a/core/src/main/java/com/github/rumsfield/konquest/manager/PlaceholderManager.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/manager/PlaceholderManager.java
@@ -339,11 +339,7 @@ public class PlaceholderManager implements KonquestPlaceholderManager {
 		String result = "";
 		KonPlayer onlinePlayerTwo = playerManager.getPlayer(playerTwo);
 		if(onlinePlayerTwo != null) {
-			int webColor = onlinePlayerTwo.getKingdom().getWebColor();
-			if(webColor == -1) {
-				webColor = onlinePlayerTwo.getKingdom().getName().hashCode() & 0xFFFFFF;
-			}
-			result = ChatUtil.parseHex(String.format("#%06X",webColor));
+			result = onlinePlayerTwo.getKingdom().getWebColorString();
 		}
 		return result;
 	}

--- a/core/src/main/java/com/github/rumsfield/konquest/model/KonKingdom.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/model/KonKingdom.java
@@ -162,6 +162,14 @@ public class KonKingdom implements Timeable, KonquestKingdom, KonPropertyFlagHol
 		return webColor;
 	}
 
+	public String getWebColorString() {
+		int webColorHash = webColor;
+		if(webColor == -1) {
+			webColorHash = getName().hashCode() & 0xFFFFFF;
+		}
+		return ChatUtil.parseHex(String.format("#%06X",webColorHash));
+	}
+
 	@Override
 	public boolean setPropertyValue(KonPropertyFlag property, boolean value) {
 		boolean result = false;

--- a/core/src/main/java/com/github/rumsfield/konquest/utility/ChatUtil.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/utility/ChatUtil.java
@@ -63,62 +63,46 @@ public class ChatUtil {
 	}
 	
 	/**
-	 * Search base string and replace
-	 * 		%PREFIX% with prefix arg
-	 * 		%SUFFIX% with suffix arg
-	 * 		%KINGDOM% with kingdom arg
-	 * 		%TITLE% with title arg
-	 * 		%NAME% with name arg
+	 * Search base string and replace built-in format tags
 	 * @param base Base format that may or may not contain %PREFIX%, %SUFFIX%, %KINGDOM%, %TITLE% or %NAME%.
 	 * @param kingdom Kingdom name to replace %KINGDOM% with
 	 * @param title Title to replace %TITLE% with
 	 * @param name Name to replace %NAME% with
 	 * @return Formatted string
 	 */
-	public static String parseFormat(String base, String prefix, String suffix, String kingdom, String title, String name, String teamColor, String nameColor, boolean formatName, boolean formatKingdom) {
+	public static String parseFormat(String base, String prefix, String suffix, String kingdom, String title, String name, String primaryColor, String secondaryColor, String kingdomWebColor) {
 		String message = base;
+		// Tags
 		if(prefix.equals("")) {
-			message = message.replace("%PREFIX% ", "");
-			message = message.replace("%PREFIX%", "");
+			message = message.replaceAll("%PREFIX%\\s*", "");
 		} else {
 			message = message.replace("%PREFIX%", prefix);
 		}
 		if(suffix.equals("")) {
-			message = message.replace("%SUFFIX% ", "");
-			message = message.replace("%SUFFIX%", "");
+			message = message.replaceAll("%SUFFIX%\\s*", "");
 		} else {
 			message = message.replace("%SUFFIX%", suffix);
 		}
 		if(kingdom.equals("")) {
-			message = message.replace("%KINGDOM% ", "");
-			message = message.replace("%KINGDOM%", "");
+			message = message.replaceAll("%KINGDOM%\\s*", "");
 		} else {
-			if(formatKingdom) {
-				message = message.replace("%KINGDOM%", teamColor+kingdom);
-			} else {
-				message = message.replace("%KINGDOM%", kingdom);
-			}
+			message = message.replace("%KINGDOM%", kingdom);
 		}
 		if(title.equals("")) {
-			message = message.replace("%TITLE% ", "");
-			message = message.replace("%TITLE%", "");
+			message = message.replaceAll("%TITLE%\\s*", "");
 		} else {
-			if(formatKingdom) {
-				message = message.replace("%TITLE%", teamColor + title);
-			} else {
-				message = message.replace("%TITLE%", title);
-			}
+			message = message.replace("%TITLE%", title);
 		}
 		if(name.equals("")) {
-			message = message.replace("%NAME% ", "");
-			message = message.replace("%NAME%", "");
+			message = message.replaceAll("%NAME%\\s*", "");
 		} else {
-			if(formatName) {
-				message = message.replace("%NAME%", nameColor+name);
-			} else {
-				message = message.replace("%NAME%", name);
-			}
+			message = message.replace("%NAME%", name);
 		}
+		// Colors
+		message = message.replace("%C1%", primaryColor);
+		message = message.replace("%C2%", secondaryColor);
+		message = message.replace("%CW%", kingdomWebColor);
+
 		return message;
 	}
 	

--- a/core/src/main/java/com/github/rumsfield/konquest/utility/CorePath.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/utility/CorePath.java
@@ -19,8 +19,7 @@ public enum CorePath {
 
 	CHAT_TAG                                              ("core.chat.tag"),
 	CHAT_MESSAGE                                          ("core.chat.message"),
-	CHAT_KINGDOM_TEAM_COLOR                               ("core.chat.kingdom_team_color"),
-	CHAT_NAME_TEAM_COLOR                                  ("core.chat.name_team_color"),
+	CHAT_DIVIDER                                          ("core.chat.divider"),
 	CHAT_ENABLE_FORMAT                                    ("core.chat.enable_format"),
 	CHAT_PRIORITY                                         ("core.chat.priority"),
 

--- a/core/src/main/resources/core.yml
+++ b/core/src/main/resources/core.yml
@@ -63,14 +63,20 @@ core:
     # Text tag for all Konquest plugin messages. Use '' to disable. Use & for color codes, or hex #000000. ('string')
     tag: '&7[&6Konquest&7]&f '
     
-    # Chat message format used for all players. Use %PREFIX%, %SUFFIX%, %KINGDOM%, %TITLE% and %NAME% as placeholders. Use & for color codes, or hex #000000. ('string')
-    message: '%PREFIX% %KINGDOM% &7| %TITLE% %NAME% %SUFFIX% '
-    
-    # Use team colors for %KINGDOM% format, else use colors from message string (true/false)
-    kingdom_team_color: true
-    
-    # Use team colors for %NAME% format, else use colors from message string (true/false)
-    name_team_color: true
+    # Chat message format that appears before the divider. Use built-in tags or PAPI placeholders. Use & for color codes, or hex #000000. ('string')
+    # Built-In Konquest Message Tags:
+    # %PREFIX%    Permissions group meta prefix
+    # %SUFFIX%    Permissions group meta suffix
+    # %KINGDOM%   Kingdom name
+    # %TITLE%     Accomplishment title
+    # %NAME%      Player's name
+    # %C1%        Primary relationship color
+    # %C2%        Secondary relationship color
+    # %CW%        Kingdom webcolor
+    message: '%PREFIX% %C1%%KINGDOM% &7| %C2%%TITLE% %C1%%NAME% %SUFFIX% '
+
+    # Text that divides the chat message format from the player's text. Use & for color codes, or hex #000000. ('string')
+    divider: '&8»&r '
     
     # Enable Konquest formatting chat messages, which overrides all other plugin chat formatting (true/false)
     enable_format: true

--- a/core/src/main/resources/core.yml
+++ b/core/src/main/resources/core.yml
@@ -75,7 +75,7 @@ core:
     # %CW%        Kingdom webcolor
     message: '%PREFIX% %C1%%KINGDOM% &7| %C2%%TITLE% %C1%%NAME% %SUFFIX% '
 
-    # Text that divides the chat message format from the player's text. Use & for color codes, or hex #000000. ('string')
+    # Text that divides the chat message format from the player's text. Use '' to disable. Use & for color codes, or hex #000000. ('string')
     divider: '&8»&r '
     
     # Enable Konquest formatting chat messages, which overrides all other plugin chat formatting (true/false)

--- a/core/src/main/resources/plugin.yml
+++ b/core/src/main/resources/plugin.yml
@@ -2,7 +2,7 @@ name: Konquest
 description: A plugin for land claiming and territory control
 author: Rumsfield
 version: @version@
-api-version: 1.16
+api-version: 1.20
 load: POSTWORLD
 main: com.github.rumsfield.konquest.KonquestPlugin
 depend: [Vault]
@@ -48,6 +48,7 @@ permissions:
       konquest.directive.*: true
       konquest.compass: true
       konquest.join: true
+      konquest.chatcolor: true
 
   konquest.command:
     description: Base command permission
@@ -337,4 +338,8 @@ permissions:
     
   konquest.prefix:
     description: Grants access to a custom prefix
+    default: false
+
+  konquest.chatcolor:
+    description: Allows players to use color format codes in chat messages
     default: false


### PR DESCRIPTION
# Konquest Pull Request

Closes #168

## Summary
Adjusts config options for chat formatting, and expands parsing of color codes in chat. Adds a new permission to allow players to use color codes in their chat messages.

## Change Details
* Added more built-in format tags for colors:
  * %C1% - primary relation color
  * %C2% - secondary relation color
  * %CW% - kingdom webcolor
* Added a config option to specify the divider text between the chat format and player message.
* Added a permission, `konquest.chatcolor`, to allow players to use color codes (&4, #ff0080, etc.) in their messages only while in global chat mode.
* Removed config options `core.chat.kingdom_team_color` and `core.chat.name_team_color` which were too restrictive. Instead, the new color tags can be used to insert relational colors anywhere in the format string.
* Updated chat command `/k chat` logic to return an error message when the config option `core.chat.enable_format` is false.
* Updated kingdom chat message formats for friendly players and admin bypass players.

## Checklist
- [x] I have merged the latest `develop` commit into this branch and resolved any conflicts.
- [x] I have tested this branch and it is working as intended.
- [x] This Pull Request is ready for review and merging.