### PR TITLE
Feature/182 pve flag rework

### DIFF
--- a/core/src/main/java/com/github/rumsfield/konquest/listener/PlayerListener.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/listener/PlayerListener.java
@@ -32,11 +32,7 @@ import org.bukkit.block.data.AnaloguePowerable;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.block.data.Powerable;
 import org.bukkit.block.data.type.*;
-import org.bukkit.entity.Entity;
-import org.bukkit.entity.EntityType;
-import org.bukkit.entity.Item;
-import org.bukkit.entity.Player;
-import org.bukkit.entity.Vehicle;
+import org.bukkit.entity.*;
 import org.bukkit.event.Event;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -1233,6 +1229,22 @@ public class PlayerListener implements Listener {
     	// Update bars
 		if(territoryTo instanceof KonBarDisplayer) {
 			((KonBarDisplayer)territoryTo).addBarPlayer(player);
+		}
+		// Handle property flag holders
+		if(territoryTo instanceof KonPropertyFlagHolder) {
+			KonPropertyFlagHolder flagHolder = (KonPropertyFlagHolder)territoryTo;
+			if(flagHolder.hasPropertyValue(KonPropertyFlag.PVE)) {
+				// Search for mobs targeting player
+				if(!flagHolder.getPropertyValue(KonPropertyFlag.PVE) && locTo.getWorld() != null) {
+					for(Entity searchEntity : locTo.getWorld().getNearbyEntities(locTo,32,32,32,(e) -> e instanceof Mob)) {
+						Mob searchMob = (Mob)searchEntity;
+						LivingEntity mobTarget = searchMob.getTarget();
+						if(mobTarget != null && mobTarget.equals(player.getBukkitPlayer())) {
+							searchMob.setTarget(null);
+						}
+					}
+				}
+			}
 		}
 		// Decide what to do for specific territories
 		if(territoryTo instanceof KonTown) {


### PR DESCRIPTION
# Konquest Pull Request

Closes #182

## Summary
Updates behavior of PVE property flag.

## Change Details
* Added check for creeper explosions, and cancels when PVE = false.
* Added damage cancel checks for explosions in protected territories.
* Added silverfish blocks, slime splits, and phantoms to blocked spawn reason list when MOBS = false.
* Added check to prevent enemy mobs from targeting players inside of territory when PVE = false.
* Added check to force nearby enemy mobs to stop targeting player that enters territory when PVE = false.

## Checklist
- [x] I have merged the latest `develop` commit into this branch and resolved any conflicts.
- [x] I have tested this branch and it is working as intended.
- [x] This Pull Request is ready for review and merging.