### PR TITLE
Feature/201 custom commands

### DIFF
--- a/core/src/main/java/com/github/rumsfield/konquest/Konquest.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/Konquest.java
@@ -1717,7 +1717,7 @@ public class Konquest implements KonquestAPI, Timeable {
 			try {
 				boolean result = Bukkit.dispatchCommand(Bukkit.getConsoleSender(), customCommand);
 				if (!result) {
-					ChatUtil.printConsoleWarning("Could not find valid target for command \""+customCommand+"\" from commands.yml entry "+commandPath);
+					ChatUtil.printConsoleWarning("Could not run command \""+customCommand+"\" from commands.yml entry "+commandPath);
 				}
 			} catch (CommandException me) {
 				ChatUtil.printConsoleError("Failed to execute custom command \""+customCommand+"\" from commands.yml entry "+commandPath);

--- a/core/src/main/java/com/github/rumsfield/konquest/Konquest.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/Konquest.java
@@ -1718,6 +1718,10 @@ public class Konquest implements KonquestAPI, Timeable {
 				boolean result = Bukkit.dispatchCommand(Bukkit.getConsoleSender(), customCommand);
 				if (!result) {
 					ChatUtil.printConsoleWarning("Could not run command \""+customCommand+"\" from commands.yml entry "+commandPath);
+					// Check for leading forward slash
+					if (customCommand.matches("^/.+")) {
+						ChatUtil.printConsoleWarning("Custom command starts with a forward slash \"/\". Remove the slash from the command in commands.yml.");
+					}
 				}
 			} catch (CommandException me) {
 				ChatUtil.printConsoleError("Failed to execute custom command \""+customCommand+"\" from commands.yml entry "+commandPath);

--- a/core/src/main/java/com/github/rumsfield/konquest/listener/BlockListener.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/listener/BlockListener.java
@@ -16,10 +16,7 @@ import com.github.rumsfield.konquest.manager.KingdomManager;
 import com.github.rumsfield.konquest.manager.PlayerManager;
 import com.github.rumsfield.konquest.manager.TerritoryManager;
 import com.github.rumsfield.konquest.model.*;
-import com.github.rumsfield.konquest.utility.ChatUtil;
-import com.github.rumsfield.konquest.utility.CorePath;
-import com.github.rumsfield.konquest.utility.MessagePath;
-import com.github.rumsfield.konquest.utility.Timer;
+import com.github.rumsfield.konquest.utility.*;
 import org.bukkit.*;
 import org.bukkit.block.Block;
 import org.bukkit.block.data.Ageable;
@@ -378,6 +375,8 @@ public class BlockListener implements Listener {
 							event.setCancelled(true);
 							return;
 						}
+						// Execute custom commands from config
+						konquest.executeCustomCommand(CustomCommandPath.RUIN_CRITICAL,player.getBukkitPlayer());
 						// Fire event for pre-capture
 						if(ruin.getRemainingCriticalHits() == 0) {
 							List<KonPlayer> rewardPlayers = konquest.getRuinManager().getRuinPlayers(ruin,player.getKingdom());
@@ -397,6 +396,8 @@ public class BlockListener implements Listener {
 						event.getBlock().getWorld().playSound(breakLoc, Sound.BLOCK_FIRE_EXTINGUISH, 1.0F, 0.6F);
 						if(hitStatus) {
 							konquest.getRuinManager().rewardPlayers(ruin,player.getKingdom());
+							// Execute custom commands from config
+							konquest.executeCustomCommand(CustomCommandPath.RUIN_CAPTURE,player.getBukkitPlayer());
 						} else {
 							// All golems target player
 							ruin.targetAllGolemsToPlayer(event.getPlayer());
@@ -1401,6 +1402,8 @@ public class BlockListener implements Listener {
 						}
 						
 					}
+					// Execute custom commands from config
+					konquest.executeCustomCommand(CustomCommandPath.TOWN_MONUMENT_CAPTURE,player.getBukkitPlayer());
 					// Update directive progress
 					konquest.getDirectiveManager().updateDirectiveProgress(player, KonDirective.CAPTURE_TOWN);
 					// Update stat
@@ -1438,12 +1441,11 @@ public class BlockListener implements Listener {
 			int defendReward = konquest.getCore().getInt(CorePath.FAVOR_REWARDS_DEFEND_RAID.getPath());
 			ChatUtil.sendNotice(player.getBukkitPlayer(), MessagePath.PROTECTION_NOTICE_CRITICAL.getMessage(remainingHits));
 			konquest.getAccomplishmentManager().modifyPlayerStat(player,KonStatsType.CRITICALS,1);
-			
 			String kingdomName = town.getKingdom().getName();
-			
+			// Execute custom commands from config
+			konquest.executeCustomCommand(CustomCommandPath.TOWN_MONUMENT_CRITICAL,player.getBukkitPlayer());
 			// Target rabbit
 			town.targetRabbitToPlayer(player.getBukkitPlayer());
-					
 			// Alert all players of enemy Kingdom when the first critical block is broken
 			if(town.getMonument().getCriticalHits() == 1) {
 				for(KonPlayer kingdomPlayer : playerManager.getPlayersInKingdom(kingdomName)) {
@@ -1456,7 +1458,6 @@ public class BlockListener implements Listener {
 					konquest.getIntegrationManager().getDiscordSrv().alertDiscordMember(allPlayer, MessagePath.PROTECTION_NOTICE_RAID_DISCORD_DIRECT.getMessage(town.getName(),kingdomName));
 				}
 			}
-			
 			// Alert all players of enemy Kingdom when half of critical blocks are broken
 			if(town.getMonument().getCriticalHits() == maxCriticalhits/2) {
 				for(KonPlayer kingdomPlayer : playerManager.getPlayersInKingdom(kingdomName)) {
@@ -1464,7 +1465,6 @@ public class BlockListener implements Listener {
 					ChatUtil.sendNotice(kingdomPlayer.getBukkitPlayer(), MessagePath.PROTECTION_NOTICE_RAID_CAPTURE_2.getMessage(town.getName(),town.getTravelName(),defendReward),ChatColor.DARK_RED);
 				}
 			}
-			
 			// Alert all players of enemy Kingdom when all but 1 critical blocks are broken
 			if(town.getMonument().getCriticalHits() == maxCriticalhits-1) {
 				for(KonPlayer kingdomPlayer : playerManager.getPlayersInKingdom(kingdomName)) {

--- a/core/src/main/java/com/github/rumsfield/konquest/listener/EntityListener.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/listener/EntityListener.java
@@ -11,6 +11,7 @@ import com.github.rumsfield.konquest.manager.PlayerManager;
 import com.github.rumsfield.konquest.manager.TerritoryManager;
 import com.github.rumsfield.konquest.utility.ChatUtil;
 import com.github.rumsfield.konquest.utility.CorePath;
+import com.github.rumsfield.konquest.utility.CustomCommandPath;
 import com.github.rumsfield.konquest.utility.MessagePath;
 
 import org.bukkit.Bukkit;
@@ -604,6 +605,10 @@ public class EntityListener implements Listener {
         			// Check for golem death
         			if(golem.getHealth() - event.getFinalDamage() <= 0) {
         				konquest.getAccomplishmentManager().modifyPlayerStat(player,KonStatsType.GOLEMS,1);
+						// Execute custom commands from config
+						if(ruin.isGolem(golem)) {
+							konquest.executeCustomCommand(CustomCommandPath.RUIN_GOLEM_KILL,player.getBukkitPlayer());
+						}
         			} else {
         				// Golem is still alive
         				ruin.targetGolemToPlayer(bukkitPlayer, golem);

--- a/core/src/main/java/com/github/rumsfield/konquest/listener/InventoryListener.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/listener/InventoryListener.java
@@ -9,6 +9,7 @@ import com.github.rumsfield.konquest.manager.PlayerManager;
 import com.github.rumsfield.konquest.model.*;
 import com.github.rumsfield.konquest.utility.ChatUtil;
 import com.github.rumsfield.konquest.utility.CorePath;
+import com.github.rumsfield.konquest.utility.CustomCommandPath;
 import com.github.rumsfield.konquest.utility.MessagePath;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
@@ -146,6 +147,8 @@ public class InventoryListener implements Listener {
 							ChatUtil.printDebug("Attempted to update loot in town "+territory.getName()+", got "+result);
 							if(result) {
 								event.getInventory().getLocation().getWorld().playSound(event.getInventory().getLocation(), Sound.ENTITY_PLAYER_LEVELUP, (float)1.0, (float)1.0);
+								// Execute custom commands from config
+								konquest.executeCustomCommand(CustomCommandPath.TOWN_MONUMENT_LOOT_OPEN,player.getBukkitPlayer());
 							} else {
 								ChatUtil.sendNotice(player.getBukkitPlayer(), MessagePath.PROTECTION_NOTICE_LOOT_LATER.getMessage());
 							}
@@ -166,6 +169,8 @@ public class InventoryListener implements Listener {
 						ChatUtil.printDebug("Attempted to update loot in ruin "+territory.getName()+", got "+result);
 						if(result) {
 							event.getInventory().getLocation().getWorld().playSound(event.getInventory().getLocation(), Sound.ENTITY_PLAYER_LEVELUP, (float)1.0, (float)1.0);
+							// Execute custom commands from config
+							konquest.executeCustomCommand(CustomCommandPath.RUIN_LOOT_OPEN,player.getBukkitPlayer());
 						} else {
 							ChatUtil.sendNotice(player.getBukkitPlayer(), MessagePath.PROTECTION_NOTICE_LOOT_CAPTURE.getMessage());
 						}

--- a/core/src/main/java/com/github/rumsfield/konquest/manager/ConfigManager.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/manager/ConfigManager.java
@@ -57,6 +57,8 @@ public class ConfigManager{
 		updateConfigVersion("loot");
 		addConfig("prefix", new KonConfig("prefix",false));
 		updateConfigVersion("prefix");
+		addConfig("commands", new KonConfig("commands",false));
+		updateConfigVersion("commands");
 
 		// Data Storage
 		migrateConfigFile("kingdoms.yml","data/kingdoms.yml");

--- a/core/src/main/java/com/github/rumsfield/konquest/utility/CustomCommandPath.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/utility/CustomCommandPath.java
@@ -1,0 +1,21 @@
+package com.github.rumsfield.konquest.utility;
+
+public enum CustomCommandPath {
+
+    RUIN_CRITICAL              ("commands.ruin_critical"),
+    RUIN_CAPTURE               ("commands.ruin_capture"),
+    RUIN_LOOT_OPEN             ("commands.ruin_loot_open"),
+    RUIN_GOLEM_KILL            ("commands.ruin_golem_kill"),
+    TOWN_MONUMENT_CRITICAL     ("commands.town_monument_critical"),
+    TOWN_MONUMENT_CAPTURE      ("commands.town_monument_capture"),
+    TOWN_MONUMENT_LOOT_OPEN    ("commands.town_monument_loot_open");
+
+    private final String path;
+    CustomCommandPath(String path) {
+        this.path = path;
+    }
+
+    public String getPath() {
+        return path;
+    }
+}

--- a/core/src/main/resources/commands.yml
+++ b/core/src/main/resources/commands.yml
@@ -1,0 +1,32 @@
+# Custom Commands
+# Instructions: Put your own custom commands to be executed during specific events.
+# Use these tags in the commands:
+#   %PLAYER% - the player's name
+#
+# For example, for a command that gives the player 5 gold ingots when they kill a Ruin golem:
+# ruin_golem_kill: 'give %PLAYER% gold_ingot 5'
+#
+# /!\ DO NOT MODIFY VERSION /!\
+version: 0.0.0
+commands:
+
+  # The command that runs when any ruin critical block is destroyed.
+  ruin_critical: ''
+
+  # The command that runs when any ruin is captured.
+  ruin_capture: ''
+
+  # The command that runs when any ruin loot chest is opened.
+  ruin_loot_open: ''
+
+  # The command that runs when any ruin golem is killed.
+  ruin_golem_kill: ''
+
+  # The command that runs when any town monument critical block is destroyed.
+  town_monument_critical: ''
+
+  # The command that runs when any town is captured.
+  town_monument_capture: ''
+
+  # The command that runs when any town monument loot chest is opened.
+  town_monument_loot_open: ''

--- a/core/src/main/resources/commands.yml
+++ b/core/src/main/resources/commands.yml
@@ -1,5 +1,6 @@
 # Custom Commands
 # Instructions: Put your own custom commands to be executed during specific events.
+# Do not include a slash "/" in the command string.
 # Use these tags in the commands:
 #   %PLAYER% - the player's name
 #


### PR DESCRIPTION
# Konquest Pull Request

Closes #201

## Summary
Adds a new config file, `commands.yml`, for specifying custom commands to run at different events. Commands can use a %PLAYER% tag to insert the player's name that was involved in the event.

## Checklist
- [x] I have merged the latest `develop` commit into this branch and resolved any conflicts.
- [x] I have tested this branch and it is working as intended.
- [x] This Pull Request is ready for review and merging.