### PR TITLE
Hotfix/217 enemy block break

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 allprojects {
     group = "com.github.rumsfield.konquest"
-    version = "1.4.2"
+    version = "1.4.3"
 }
 
 subprojects {

--- a/core/src/main/java/com/github/rumsfield/konquest/listener/BlockListener.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/listener/BlockListener.java
@@ -210,7 +210,7 @@ public class BlockListener implements Listener {
 							return;
 						}
 						// Check for enemy player
-						if(playerRole.equals(KonquestRelationshipType.ENEMY)) {
+						if (playerRole.equals(KonquestRelationshipType.ENEMY)) {
 							// The player is an enemy and may edit blocks
 							// Check for capital capture conditions
 							if(isCapital && territory.getKingdom().isCapitalImmune()) {
@@ -303,7 +303,7 @@ public class BlockListener implements Listener {
 							}
 							// Update directives
 							konquest.getDirectiveManager().updateDirectiveProgress(player, KonDirective.ATTACK_TOWN);
-						} if(playerRole.equals(KonquestRelationshipType.ALLY)) {
+						} else if(playerRole.equals(KonquestRelationshipType.ALLY)) {
 							// Player is in an allied kingdom
 							// Can break blocks if town option Allied Building is true.
 							if(isAlliedBuildingEnable) {

--- a/core/src/main/java/com/github/rumsfield/konquest/listener/BlockListener.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/listener/BlockListener.java
@@ -517,7 +517,10 @@ public class BlockListener implements Listener {
 	 * Fires when blocks are placed.
 	 * Prevent placing blocks inside protected territories.
 	 * Check for barbarian bed placement.
+	 * Player#setBedSpawnLocation is deprecated, but keep using it
+	 * for backwards compatibility to 1.16.
 	 */
+	@SuppressWarnings( "deprecation" )
 	@EventHandler(priority = EventPriority.LOWEST)
     public void onBlockPlace(BlockPlaceEvent event) {
 		if(event.isCancelled()) {

--- a/core/src/main/java/com/github/rumsfield/konquest/listener/BlockListener.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/listener/BlockListener.java
@@ -644,7 +644,7 @@ public class BlockListener implements Listener {
 							return;
 						}
 						// Check for enemy player
-						if(playerRole.equals(KonquestRelationshipType.ENEMY)) {
+						if (playerRole.equals(KonquestRelationshipType.ENEMY)) {
 							// The player is an enemy and may edit blocks
 							// Check for capital capture conditions
 							if(isCapital && territory.getKingdom().isCapitalImmune()) {
@@ -676,7 +676,7 @@ public class BlockListener implements Listener {
 								event.setCancelled(true);
 								return;
 							}
-						} if(playerRole.equals(KonquestRelationshipType.ALLY)) {
+						} else if(playerRole.equals(KonquestRelationshipType.ALLY)) {
 							// Player is in an allied kingdom
 							// Can place blocks if town option Allied Building is true.
 							if(isAlliedBuildingEnable) {

--- a/core/src/main/java/com/github/rumsfield/konquest/utility/ChatUtil.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/utility/ChatUtil.java
@@ -383,15 +383,33 @@ public class ChatUtil {
 	}
 
 	public static void sendKonBlockedProtectionTitle(KonPlayer player) {
+		printDebug("Blocked Protection by player "+player.getBukkitPlayer().getName());
+		showDebugStackTrace();
 		sendKonPriorityTitle(player, "", Konquest.blockedProtectionColor+MessagePath.PROTECTION_ERROR_BLOCKED.getMessage(), 1, 10, 10);
 	}
 
 	public static void sendKonBlockedFlagTitle(KonPlayer player) {
+		printDebug("Blocked Flag by player "+player.getBukkitPlayer().getName());
+		showDebugStackTrace();
 		sendKonPriorityTitle(player, "", Konquest.blockedFlagColor+MessagePath.PROTECTION_ERROR_BLOCKED.getMessage(), 1, 10, 10);
 	}
 
 	public static void sendKonBlockedShieldTitle(KonPlayer player) {
+		printDebug("Blocked Shield by player "+player.getBukkitPlayer().getName());
+		showDebugStackTrace();
 		sendKonPriorityTitle(player, "", Konquest.blockedShieldColor+MessagePath.PROTECTION_ERROR_BLOCKED.getMessage(), 1, 10, 10);
+	}
+
+	private static void showDebugStackTrace() {
+		if(Konquest.getInstance().getCore().getBoolean(CorePath.DEBUG.getPath())) {
+			// Get stack trace
+			for (StackTraceElement element : Thread.currentThread().getStackTrace()) {
+				String traceStr = element.toString();
+				if (traceStr.contains("Konquest")) {
+					Bukkit.getServer().getConsoleSender().sendMessage(element.toString());
+				}
+			}
+		}
 	}
 	
 }


### PR DESCRIPTION
# Konquest Pull Request

Closes #217

## Summary
Fixes logic error that prevented enemy players from editing blocks in towns and capitals. Changes plugin version to 1.4.3.

## Checklist
- [x] I have merged the latest `develop` commit into this branch and resolved any conflicts.
- [x] I have tested this branch and it is working as intended.
- [x] This Pull Request is ready for review and merging.