### PR TITLE
Bugfix/226 capital upgrades management

### DIFF
--- a/core/src/main/java/com/github/rumsfield/konquest/command/admin/TownAdminCommand.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/command/admin/TownAdminCommand.java
@@ -561,6 +561,7 @@ public class TownAdminCommand extends CommandBase {
 						}
 						// Add the player as a resident
 						if(town.addPlayerResident(residentPlayer.getOfflineBukkitPlayer(),false)) {
+							town.removeJoinRequest(residentID);
 							ChatUtil.sendNotice(sender, MessagePath.COMMAND_TOWN_NOTICE_ADD_RESIDENT.getMessage(playerName,townName));
 						} else {
 							// Player is already a resident
@@ -570,6 +571,7 @@ public class TownAdminCommand extends CommandBase {
 					case "kick":
 						// Remove the player as a resident
 						if(town.removePlayerResident(residentPlayer.getOfflineBukkitPlayer())) {
+							town.removeJoinRequest(residentID);
 							ChatUtil.sendNotice(sender, MessagePath.COMMAND_TOWN_NOTICE_KICK_RESIDENT.getMessage(playerName,townName));
 						} else {
 							// Player was not a resident

--- a/core/src/main/java/com/github/rumsfield/konquest/command/admin/TownAdminCommand.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/command/admin/TownAdminCommand.java
@@ -549,6 +549,7 @@ public class TownAdminCommand extends CommandBase {
 					ChatUtil.sendError(sender, MessagePath.GENERIC_ERROR_UNKNOWN_NAME.getMessage(residentPlayerName));
 					return;
 				}
+				UUID residentID = residentPlayer.getOfflineBukkitPlayer().getUniqueId();
 				String playerName = residentPlayer.getOfflineBukkitPlayer().getName();
 				// Parse sub-commands
 				switch(residentSubCmd.toLowerCase()) {
@@ -619,11 +620,18 @@ public class TownAdminCommand extends CommandBase {
 						}
 						// Make the player into the new town lord
 						town.setPlayerLord(residentPlayer.getOfflineBukkitPlayer());
+						town.removeJoinRequest(residentID);
 						ChatUtil.sendNotice(sender, MessagePath.COMMAND_TOWN_NOTICE_LORD_SUCCESS.getMessage(townName,playerName));
 						break;
 					default:
 						sendInvalidArgMessage(sender);
-						break;
+						return;
+				}
+				// Update membership stats for online players
+				KonPlayer onlinePlayer = konquest.getPlayerManager().getPlayerFromID(residentID);
+				if (onlinePlayer != null) {
+					// Player is valid and online
+					konquest.getKingdomManager().updatePlayerMembershipStats(onlinePlayer);
 				}
 				break;
 			case "plots":
@@ -784,7 +792,7 @@ public class TownAdminCommand extends CommandBase {
 							}
 							break;
 						case "lord":
-							for (OfflinePlayer offlinePlayer : town.getPlayerResidents()) {
+							for (OfflinePlayer offlinePlayer : town.getKingdom().getPlayerMembers()) {
 								String name = offlinePlayer.getName();
 								if (name != null && !town.isLord(offlinePlayer.getUniqueId())) {
 									tabList.add(name);

--- a/core/src/main/java/com/github/rumsfield/konquest/model/KonTown.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/model/KonTown.java
@@ -1279,17 +1279,15 @@ public class KonTown extends KonTerritory implements KonquestTown, KonBarDisplay
 	
 	public void setLord(UUID id) {
 		lord = id;
-		if(!residents.containsKey(id)) {
-			residents.put(id,true);
-			getKonquest().getUpgradeManager().updateTownDisabledUpgrades(this);
-			getKonquest().getMapHandler().drawLabel(this);
-		}
+		residents.put(id,true);
+		getKonquest().getUpgradeManager().updateTownDisabledUpgrades(this);
+		getKonquest().getMapHandler().drawLabel(this);
 	}
 	
 	public boolean isLord(UUID id) {
 		boolean status = false;
 		if(lord != null) {
-			status =id.equals(lord);
+			status = id.equals(lord);
 		}
 		return status;
 	}
@@ -1297,7 +1295,8 @@ public class KonTown extends KonTerritory implements KonquestTown, KonBarDisplay
 	public boolean isPlayerLord(OfflinePlayer player) {
 		return isLord(player.getUniqueId());
 	}
-	
+
+	// Changes resident's knight flag, cannot be lord
 	public boolean setPlayerKnight(OfflinePlayer player, boolean val) {
 		boolean status = true;
 		UUID playerUUID = player.getUniqueId();
@@ -1313,7 +1312,7 @@ public class KonTown extends KonTerritory implements KonquestTown, KonBarDisplay
 	public boolean isPlayerKnight(OfflinePlayer player) {
 		boolean status = true;
 		UUID playerUUID = player.getUniqueId();
-		if(residents.containsKey(playerUUID)) {
+		if(residents.containsKey(playerUUID) || isLord(playerUUID)) {
 			status = residents.get(playerUUID);
 		} else {
 			status = false;


### PR DESCRIPTION
# Konquest Pull Request

Closes #226

## Summary
Fixes town lord logic to ensure that when a player becomes the lord of a town, they are always included in the residents list with the knight flag set to true. Also updates the admin town command to correctly clear town join requests when managing residents (adding, kicking, giving lord).

The original bug reporting for this issue could not be reproduced (town heart upgrade not working for capitals).

## Checklist
- [x] I have merged the latest `develop` commit into this branch and resolved any conflicts.
- [x] I have tested this branch and it is working as intended.
- [x] This Pull Request is ready for review and merging.