### PR TITLE
Feature/229 minecraft 1 21 api

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ The [`doc`](./doc) folder contains auto-generated Javadoc files.
 
 ### Building
 Konquest uses Gradle for most dependencies, building and generating Javadoc.
-* Use Java 11 JDK or newer
+* Use Java 21 JDK or newer
+  * If using IntelliJ IDEA, must be version 2024 or newer
 * Requires Git
 
 Use these commands to build from source:

--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -4,7 +4,8 @@ plugins {
 }
 
 dependencies{
-    compileOnly("org.spigotmc:spigot-api:1.16.5-R0.1-SNAPSHOT")
+    //compileOnly("org.spigotmc:spigot-api:1.16.5-R0.1-SNAPSHOT")
+    compileOnly("org.spigotmc:spigot-api:1.21-R0.1-SNAPSHOT")
 }
 
 tasks {

--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -4,8 +4,7 @@ plugins {
 }
 
 dependencies{
-    //compileOnly("org.spigotmc:spigot-api:1.16.5-R0.1-SNAPSHOT")
-    compileOnly("org.spigotmc:spigot-api:1.21-R0.1-SNAPSHOT")
+    compileOnly("org.spigotmc:spigot-api:1.21-R0.1-SNAPSHOT") // Primary API
 }
 
 tasks {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,6 +7,8 @@ subprojects {
     repositories {
         mavenCentral()
         maven("https://hub.spigotmc.org/nexus/content/repositories/snapshots/")
+        maven("https://oss.sonatype.org/content/repositories/snapshots")
+        maven("https://oss.sonatype.org/content/repositories/central")
         flatDir {
             dirs("$rootDir/lib")
         }

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -43,7 +43,8 @@ repositories{
 
 dependencies{
     // Spigot
-    compileOnly("org.spigotmc:spigot-api:1.21-R0.1-SNAPSHOT") // Primary API
+    //compileOnly("org.spigotmc:spigot-api:1.21-R0.1-SNAPSHOT") // Primary API
+    compileOnly("org.spigotmc:spigot-api:1.20.6-R0.1-SNAPSHOT") // Primary API
     compileOnly("org.spigotmc:spigot-1.17.1-R0.1-SNAPSHOT-remapped") // for nms packets, local lib
     compileOnly("org.spigotmc:spigot-1.16.5-R0.1-SNAPSHOT") // for nms packets, local lib
 

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -13,7 +13,10 @@ repositories{
     // Placeholder API
     maven("https://repo.extendedclip.com/content/repositories/placeholderapi/")
 
-    // Dynmap & QuickShop
+    // Dynmap
+    maven("https://repo.mikeprimm.com/")
+
+    // QuickShop
     maven("https://repo.codemc.io/repository/maven-public/")
 
     // ProtocolLib
@@ -39,14 +42,18 @@ repositories{
 }
 
 dependencies{
-    compileOnly("org.spigotmc:spigot-api:1.20.4-R0.1-SNAPSHOT")
-    compileOnly("org.spigotmc:spigot-api:1.16.5-R0.1-SNAPSHOT")
-    compileOnly("org.spigotmc:spigot-1.17.1-R0.1-SNAPSHOT-remapped")
-    compileOnly("org.spigotmc:spigot-1.16.5-R0.1-SNAPSHOT")
+    // Spigot
+    compileOnly("org.spigotmc:spigot-api:1.21-R0.1-SNAPSHOT") // Primary API
+    compileOnly("org.spigotmc:spigot-1.17.1-R0.1-SNAPSHOT-remapped") // for nms packets, local lib
+    compileOnly("org.spigotmc:spigot-1.16.5-R0.1-SNAPSHOT") // for nms packets, local lib
+
+    // Integrated third-party plugins
     compileOnly("com.comphenix.protocol:ProtocolLib:5.0.0")
-    compileOnly("org.maxgamer:QuickShop:5.1.2.2-SNAPSHOT")
+    compileOnly("com.github.jikoo.OpenInv:openinvapi:4.3.1")
+    compileOnly("org.maxgamer:QuickShop:5.1.2.5-SNAPSHOT")
     compileOnly("com.acrobot.chestshop:chestshop:3.12")
-    compileOnly("org.dynmap:Dynmap:3.4-beta-2-spigot")
+    compileOnly("us.dynmap:DynmapCoreAPI:3.6")
+    compileOnly("us.dynmap:dynmap-api:3.6")
     compileOnly("com.github.MilkBowl:VaultAPI:1.7.1")
     compileOnly("com.discordsrv:discordsrv:1.27.0")
     compileOnly("me.clip:placeholderapi:2.11.2")
@@ -60,7 +67,22 @@ dependencies{
     implementation("org.xerial:sqlite-jdbc:3.40.1.0")
     implementation(project(":api"))
 }
+/*
+configurations.all {
+    resolutionStrategy.force("org.spigotmc:spigot-api:1.20.6-R0.1-SNAPSHOT")
+}
+*/
 
+/*
+configurations.all {
+    resolutionStrategy.eachDependency {
+        if (requested.group == "org.spigotmc" && requested.name == "spigot") {
+            useVersion("1.20.6-R0.1-SNAPSHOT")
+            because("Ensure spigot-api is preferred for overlapping classes")
+        }
+    }
+}
+*/
 tasks {
     shadowJar {
         archiveBaseName.set("Konquest")

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -43,8 +43,7 @@ repositories{
 
 dependencies{
     // Spigot
-    //compileOnly("org.spigotmc:spigot-api:1.21-R0.1-SNAPSHOT") // Primary API
-    compileOnly("org.spigotmc:spigot-api:1.20.6-R0.1-SNAPSHOT") // Primary API
+    compileOnly("org.spigotmc:spigot-api:1.21-R0.1-SNAPSHOT") // Primary API
     compileOnly("org.spigotmc:spigot-1.17.1-R0.1-SNAPSHOT-remapped") // for nms packets, local lib
     compileOnly("org.spigotmc:spigot-1.16.5-R0.1-SNAPSHOT") // for nms packets, local lib
 

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -67,22 +67,7 @@ dependencies{
     implementation("org.xerial:sqlite-jdbc:3.40.1.0")
     implementation(project(":api"))
 }
-/*
-configurations.all {
-    resolutionStrategy.force("org.spigotmc:spigot-api:1.20.6-R0.1-SNAPSHOT")
-}
-*/
 
-/*
-configurations.all {
-    resolutionStrategy.eachDependency {
-        if (requested.group == "org.spigotmc" && requested.name == "spigot") {
-            useVersion("1.20.6-R0.1-SNAPSHOT")
-            because("Ensure spigot-api is preferred for overlapping classes")
-        }
-    }
-}
-*/
 tasks {
     shadowJar {
         archiveBaseName.set("Konquest")

--- a/core/src/main/java/com/github/rumsfield/konquest/Konquest.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/Konquest.java
@@ -161,7 +161,7 @@ public class Konquest implements KonquestAPI, Timeable {
 		this.pingTimer = new Timer(this);
 		this.saveIntervalSeconds = 0;
 		this.offlineTimeoutSeconds = 0;
-		this.isVersionSupported = true;
+		this.isVersionSupported = false;
 		this.isVersionHandlerEnabled = false;
 		this.teleportLocationQueue = new HashMap<>();
 	}
@@ -221,36 +221,32 @@ public class Konquest implements KonquestAPI, Timeable {
 	}
 	
 	private void initVersionHandlers() {
-		String version;
-    	try {
-    		version = Bukkit.getServer().getClass().getPackage().getName().split("\\.")[3];
-    	} catch (ArrayIndexOutOfBoundsException e) {
-    		ChatUtil.printConsoleError("Failed to determine server version.");
-    		return;
-    	}
-    	ChatUtil.printConsoleAlert("Your server version is "+version+", "+Bukkit.getServer().getBukkitVersion());
+    	ChatUtil.printConsoleAlert("Your server version is "+Bukkit.getServer().getBukkitVersion());
     	boolean isProtocolLibEnabled = integrationManager.getProtocolLib().isEnabled();
     	// Version-specific cases
     	try {
-	    	switch(version) {
-	    		case "v1_16_R3":
+	    	switch(CompatibilityUtil.getApiVersion()) {
+	    		case V1_16_5:
+					isVersionSupported = true;
 					if(isProtocolLibEnabled) { versionHandler = new Handler_1_16_R3(); }
 	    			break;
-	    		case "v1_17_R1":
+	    		case V1_17_1:
+					isVersionSupported = true;
 					if(isProtocolLibEnabled) { versionHandler = new Handler_1_17_R1(); }
 	    			break;
-	    		case "v1_18_R1":
+	    		case V1_18_1:
+					isVersionSupported = true;
 					if(isProtocolLibEnabled) { versionHandler = new Handler_1_18_R1(); }
 	    			break;
-	    		case "v1_18_R2":
+	    		case V1_18_2:
+					isVersionSupported = true;
 					if(isProtocolLibEnabled) { versionHandler = new Handler_1_18_R2(); }
 	    			break;
-	    		case "v1_19_R1":
-				case "v1_19_R2":
-				case "v1_19_R3":
-				case "v1_20_R1":
-				case "v1_20_R2":
-				case "v1_20_R3":
+	    		case V1_19_4:
+				case V1_20_4:
+				case V1_20_6:
+				case V1_21_0:
+					isVersionSupported = true;
 					if(isProtocolLibEnabled) { versionHandler = new Handler_1_19_R1(); }
 	    			break;
 	    		default:

--- a/core/src/main/java/com/github/rumsfield/konquest/Konquest.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/Konquest.java
@@ -22,6 +22,7 @@ import org.bukkit.command.CommandException;
 import org.bukkit.command.CommandSender;
 import org.bukkit.command.ConsoleCommandSender;
 import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.Villager;
 import org.bukkit.event.Event;
@@ -175,7 +176,7 @@ public class Konquest implements KonquestAPI, Timeable {
 		ChatUtil.printDebug("Debug is "+debug);
 		String worldName = getCore().getString(CorePath.WORLD_NAME.getPath());
 		ChatUtil.printDebug("Primary world is "+worldName);
-		
+
 		initColors();
 		languageManager.initialize();
 		kingdomManager.loadCriticalBlocks(); // load critical block material before sanctuaries
@@ -245,7 +246,7 @@ public class Konquest implements KonquestAPI, Timeable {
 	    		case V1_19_4:
 				case V1_20_4:
 				case V1_20_6:
-				case V1_21_0:
+				case V1_21:
 					isVersionSupported = true;
 					if(isProtocolLibEnabled) { versionHandler = new Handler_1_19_R1(); }
 	    			break;

--- a/core/src/main/java/com/github/rumsfield/konquest/Konquest.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/Konquest.java
@@ -225,7 +225,7 @@ public class Konquest implements KonquestAPI, Timeable {
     	boolean isProtocolLibEnabled = integrationManager.getProtocolLib().isEnabled();
     	// Version-specific cases
     	try {
-	    	switch(CompatibilityUtil.getApiVersion()) {
+	    	switch(CompatibilityUtil.apiVersion) {
 	    		case V1_16_5:
 					isVersionSupported = true;
 					if(isProtocolLibEnabled) { versionHandler = new Handler_1_16_R3(); }

--- a/core/src/main/java/com/github/rumsfield/konquest/KonquestPlugin.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/KonquestPlugin.java
@@ -37,6 +37,7 @@ public class KonquestPlugin extends JavaPlugin {
 	boolean isSetupEconomy = false;
 	boolean isSetupMetrics = false;
 	boolean isSetupPlaceholders = false;
+	boolean isEnchantmentsValidated = false;
 
 	@Override
 	public void onLoad() {
@@ -75,6 +76,8 @@ public class KonquestPlugin extends JavaPlugin {
         registerApi(konquest);
         // Register placeholders
 		isSetupPlaceholders = registerPlaceholders();
+		// Validate API Enchantments
+		isEnchantmentsValidated = CompatibilityUtil.validateEnchantments();
         // Check for updates
         checkForUpdates();
         // Done!
@@ -203,7 +206,8 @@ public class KonquestPlugin extends JavaPlugin {
 				String.format(lineTemplate,"Economy Linked",boolean2status(isSetupEconomy)),
 				String.format(lineTemplate,"Placeholders Registered",boolean2status(isSetupPlaceholders)),
 				String.format(lineTemplate,"Team Colors Registered",boolean2status(konquest.isVersionHandlerEnabled())),
-				String.format(lineTemplate,"Minecraft Version Supported",boolean2status(konquest.isVersionSupported()))
+				String.format(lineTemplate,"Minecraft Version Supported",boolean2status(konquest.isVersionSupported())),
+				String.format(lineTemplate,"API Enchantments Validated",boolean2status(isEnchantmentsValidated))
 		};
 		ChatUtil.printConsoleAlert("Final Status...");
 		for (String row : status) {

--- a/core/src/main/java/com/github/rumsfield/konquest/display/icon/AdminCommandIcon.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/display/icon/AdminCommandIcon.java
@@ -3,6 +3,7 @@ package com.github.rumsfield.konquest.display.icon;
 import com.github.rumsfield.konquest.Konquest;
 import com.github.rumsfield.konquest.command.admin.AdminCommandType;
 import com.github.rumsfield.konquest.manager.DisplayManager;
+import com.github.rumsfield.konquest.utility.CompatibilityUtil;
 import org.bukkit.ChatColor;
 import org.bukkit.inventory.ItemFlag;
 import org.bukkit.inventory.ItemStack;
@@ -26,20 +27,9 @@ public class AdminCommandIcon  implements MenuIcon{
     }
 
     private ItemStack initItem() {
-        ItemStack item = new ItemStack(command.iconMaterial());
-        ItemMeta meta = item.getItemMeta();
-        assert meta != null;
-        for(ItemFlag flag : ItemFlag.values()) {
-            if(!meta.hasItemFlag(flag)) {
-                meta.addItemFlags(flag);
-            }
-        }
-        List<String> loreList = new ArrayList<>();
-        loreList.addAll(Konquest.stringPaginate(command.description(),loreColor));
-        meta.setDisplayName(""+ChatColor.GOLD+ChatColor.ITALIC+getName());
-        meta.setLore(loreList);
-        item.setItemMeta(meta);
-        return item;
+        List<String> loreList = new ArrayList<>(Konquest.stringPaginate(command.description(), loreColor));
+        String name = ""+ChatColor.GOLD+ChatColor.ITALIC+getName();
+        return CompatibilityUtil.buildItem(command.iconMaterial(), name, loreList);
     }
 
     public AdminCommandType getCommand() {

--- a/core/src/main/java/com/github/rumsfield/konquest/display/icon/ArmorIcon.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/display/icon/ArmorIcon.java
@@ -2,6 +2,7 @@ package com.github.rumsfield.konquest.display.icon;
 
 import com.github.rumsfield.konquest.manager.DisplayManager;
 import com.github.rumsfield.konquest.model.KonArmor;
+import com.github.rumsfield.konquest.utility.CompatibilityUtil;
 import com.github.rumsfield.konquest.utility.MessagePath;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
@@ -45,7 +46,7 @@ public class ArmorIcon implements MenuIcon {
 		ItemStack item = new ItemStack(itemMaterial,1);
 		ItemMeta meta = item.getItemMeta();
 		assert meta != null;
-		meta.addEnchant(Enchantment.PROTECTION_ENVIRONMENTAL, 1, true);
+		meta.addEnchant(CompatibilityUtil.getProtectionEnchantment(), 1, true);
 		for(ItemFlag flag : ItemFlag.values()) {
 			if(!meta.hasItemFlag(flag)) {
 				meta.addItemFlags(flag);

--- a/core/src/main/java/com/github/rumsfield/konquest/display/icon/ArmorIcon.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/display/icon/ArmorIcon.java
@@ -43,15 +43,6 @@ public class ArmorIcon implements MenuIcon {
 		}else {
 			itemMaterial = Material.IRON_BARS;
 		}
-		ItemStack item = new ItemStack(itemMaterial,1);
-		ItemMeta meta = item.getItemMeta();
-		assert meta != null;
-		meta.addEnchant(CompatibilityUtil.getProtectionEnchantment(), 1, true);
-		for(ItemFlag flag : ItemFlag.values()) {
-			if(!meta.hasItemFlag(flag)) {
-				meta.addItemFlags(flag);
-			}
-		}
 		int totalCost = armor.getCost() + (armor.getCostPerResident()*population) + (armor.getCostPerLand()*land);
 		List<String> loreList = new ArrayList<>();
 		loreList.add(ChatColor.DARK_AQUA+""+armor.getBlocks());
@@ -59,10 +50,8 @@ public class ArmorIcon implements MenuIcon {
     	if(isAvailable) {
     		loreList.add(hintColor+MessagePath.MENU_SHIELD_HINT.getMessage());
     	}
-    	meta.setDisplayName(ChatColor.GOLD+armor.getId()+" "+MessagePath.LABEL_ARMOR.getMessage());
-		meta.setLore(loreList);
-		item.setItemMeta(meta);
-		return item;
+		String name = ChatColor.GOLD+armor.getId()+" "+MessagePath.LABEL_ARMOR.getMessage();
+		return CompatibilityUtil.buildItem(itemMaterial, name, loreList, true);
 	}
 	
 	public KonArmor getArmor() {

--- a/core/src/main/java/com/github/rumsfield/konquest/display/icon/CommandIcon.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/display/icon/CommandIcon.java
@@ -3,6 +3,7 @@ package com.github.rumsfield.konquest.display.icon;
 import com.github.rumsfield.konquest.Konquest;
 import com.github.rumsfield.konquest.command.CommandType;
 import com.github.rumsfield.konquest.manager.DisplayManager;
+import com.github.rumsfield.konquest.utility.CompatibilityUtil;
 import com.github.rumsfield.konquest.utility.MessagePath;
 import org.bukkit.ChatColor;
 import org.bukkit.inventory.ItemFlag;
@@ -32,14 +33,6 @@ public class CommandIcon implements MenuIcon{
 	}
 
 	private ItemStack initItem() {
-		ItemStack item = new ItemStack(command.iconMaterial());
-		ItemMeta meta = item.getItemMeta();
-		assert meta != null;
-		for(ItemFlag flag : ItemFlag.values()) {
-			if(!meta.hasItemFlag(flag)) {
-				meta.addItemFlags(flag);
-			}
-		}
 		List<String> loreList = new ArrayList<>();
 		if(cost > 0) {
 			loreList.add(loreColor+MessagePath.LABEL_COST.getMessage()+": "+valueColor+cost);
@@ -48,10 +41,8 @@ public class CommandIcon implements MenuIcon{
 			loreList.add(loreColor+MessagePath.LABEL_INCREMENT_COST.getMessage()+": "+valueColor+cost_incr);
 		}
 		loreList.addAll(Konquest.stringPaginate(command.description(),loreColor));
-		meta.setDisplayName(ChatColor.GOLD+getName());
-		meta.setLore(loreList);
-		item.setItemMeta(meta);
-		return item;
+		String name = ChatColor.GOLD+getName();
+		return CompatibilityUtil.buildItem(command.iconMaterial(), name, loreList);
 	}
 	
 	public CommandType getCommand() {

--- a/core/src/main/java/com/github/rumsfield/konquest/display/icon/DiplomacyIcon.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/display/icon/DiplomacyIcon.java
@@ -2,6 +2,7 @@ package com.github.rumsfield.konquest.display.icon;
 
 import com.github.rumsfield.konquest.Konquest;
 import com.github.rumsfield.konquest.api.model.KonquestDiplomacyType;
+import com.github.rumsfield.konquest.utility.CompatibilityUtil;
 import com.github.rumsfield.konquest.utility.Labeler;
 import org.bukkit.ChatColor;
 import org.bukkit.inventory.ItemFlag;
@@ -41,14 +42,6 @@ public class DiplomacyIcon implements MenuIcon {
 
 	@Override
 	public ItemStack getItem() {
-		ItemStack item = new ItemStack(relation.getIcon(),1);
-		ItemMeta meta = item.getItemMeta();
-		assert meta != null;
-		for(ItemFlag flag : ItemFlag.values()) {
-			if(!meta.hasItemFlag(flag)) {
-				meta.addItemFlags(flag);
-			}
-		}
 		List<String> itemLore = new ArrayList<>(lore);
 		String nameColor = ""+ChatColor.GOLD;
 		switch(relation) {
@@ -67,10 +60,8 @@ public class DiplomacyIcon implements MenuIcon {
 			default:
 				break;
 		}
-		meta.setDisplayName(nameColor+getName());
-		meta.setLore(itemLore);
-		item.setItemMeta(meta);
-		return item;
+		String name = nameColor+getName();
+		return CompatibilityUtil.buildItem(relation.getIcon(), name, itemLore);
 	}
 
 	@Override

--- a/core/src/main/java/com/github/rumsfield/konquest/display/icon/InfoIcon.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/display/icon/InfoIcon.java
@@ -1,5 +1,6 @@
 package com.github.rumsfield.konquest.display.icon;
 
+import com.github.rumsfield.konquest.utility.CompatibilityUtil;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemFlag;
 import org.bukkit.inventory.ItemStack;
@@ -28,18 +29,8 @@ public class InfoIcon implements MenuIcon{
 	}
 
 	private ItemStack initItem() {
-		ItemStack item = new ItemStack(mat);
-		ItemMeta meta = item.getItemMeta();
-		assert meta != null;
-		for(ItemFlag flag : ItemFlag.values()) {
-			if(!meta.hasItemFlag(flag)) {
-				meta.addItemFlags(flag);
-			}
-		}
-		meta.setDisplayName(getName());
-		meta.setLore(lore);
-		item.setItemMeta(meta);
-		return item;
+		String name = getName();
+		return CompatibilityUtil.buildItem(mat, name, lore);
 	}
 	
 	public void setInfo(String info) {

--- a/core/src/main/java/com/github/rumsfield/konquest/display/icon/KingdomIcon.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/display/icon/KingdomIcon.java
@@ -2,6 +2,7 @@ package com.github.rumsfield.konquest.display.icon;
 
 import com.github.rumsfield.konquest.manager.DisplayManager;
 import com.github.rumsfield.konquest.model.KonKingdom;
+import com.github.rumsfield.konquest.utility.CompatibilityUtil;
 import com.github.rumsfield.konquest.utility.MessagePath;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
@@ -58,7 +59,7 @@ public class KingdomIcon implements MenuIcon {
 			loreList.add(propertyColor+MessagePath.LABEL_OPEN.getMessage());
 		}
 		if(kingdom.isOfflineProtected()) {
-			meta.addEnchant(Enchantment.PROTECTION_ENVIRONMENTAL, 1, true);
+			meta.addEnchant(CompatibilityUtil.getProtectionEnchantment(), 1, true);
 			loreList.add(propertyColor+MessagePath.LABEL_PROTECTED.getMessage());
 		}
 		loreList.add(loreColor+MessagePath.LABEL_TOWNS.getMessage()+": "+valueColor+kingdom.getNumTowns());

--- a/core/src/main/java/com/github/rumsfield/konquest/display/icon/KingdomIcon.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/display/icon/KingdomIcon.java
@@ -42,10 +42,8 @@ public class KingdomIcon implements MenuIcon {
 		if(kingdom.isAdminOperated()) {
 			material = Material.GOLDEN_HELMET;
 		}
-		ItemStack item = new ItemStack(material,1);
-		ItemMeta meta = item.getItemMeta();
-		assert meta != null;
 		// Add applicable labels
+		boolean isProtected = false;
 		List<String> loreList = new ArrayList<>();
 		if(kingdom.isAdminOperated()) {
 			loreList.add(propertyColor+MessagePath.LABEL_ADMIN_KINGDOM.getMessage());
@@ -59,21 +57,14 @@ public class KingdomIcon implements MenuIcon {
 			loreList.add(propertyColor+MessagePath.LABEL_OPEN.getMessage());
 		}
 		if(kingdom.isOfflineProtected()) {
-			meta.addEnchant(CompatibilityUtil.getProtectionEnchantment(), 1, true);
+			isProtected = true;
 			loreList.add(propertyColor+MessagePath.LABEL_PROTECTED.getMessage());
 		}
 		loreList.add(loreColor+MessagePath.LABEL_TOWNS.getMessage()+": "+valueColor+kingdom.getNumTowns());
 		loreList.add(loreColor+MessagePath.LABEL_MEMBERS.getMessage()+": "+valueColor+kingdom.getNumMembers());
 		loreList.addAll(lore);
-		for(ItemFlag flag : ItemFlag.values()) {
-			if(!meta.hasItemFlag(flag)) {
-				meta.addItemFlags(flag);
-			}
-		}
-		meta.setDisplayName(contextColor+kingdom.getName());
-		meta.setLore(loreList);
-		item.setItemMeta(meta);
-		return item;
+		String name = contextColor+kingdom.getName();
+		return CompatibilityUtil.buildItem(material, name, loreList, isProtected);
 	}
 	
 	public KonKingdom getKingdom() {

--- a/core/src/main/java/com/github/rumsfield/konquest/display/icon/OptionIcon.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/display/icon/OptionIcon.java
@@ -1,6 +1,7 @@
 package com.github.rumsfield.konquest.display.icon;
 
 import com.github.rumsfield.konquest.model.KonTownOption;
+import com.github.rumsfield.konquest.utility.CompatibilityUtil;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemFlag;
 import org.bukkit.inventory.ItemStack;
@@ -27,18 +28,8 @@ public class OptionIcon implements MenuIcon {
 	}
 	
 	private ItemStack initItem() {
-		ItemStack item = new ItemStack(mat);
-		ItemMeta meta = item.getItemMeta();
-		assert meta != null;
-		for(ItemFlag flag : ItemFlag.values()) {
-			if(!meta.hasItemFlag(flag)) {
-				meta.addItemFlags(flag);
-			}
-		}
-		meta.setDisplayName(getName());
-		meta.setLore(lore);
-		item.setItemMeta(meta);
-		return item;
+		String name = getName();
+		return CompatibilityUtil.buildItem(mat, name, lore);
 	}
 	
 	public KonTownOption getOption() {

--- a/core/src/main/java/com/github/rumsfield/konquest/display/icon/PlayerIcon.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/display/icon/PlayerIcon.java
@@ -2,6 +2,7 @@ package com.github.rumsfield.konquest.display.icon;
 
 import com.github.rumsfield.konquest.Konquest;
 import com.github.rumsfield.konquest.manager.DisplayManager;
+import com.github.rumsfield.konquest.utility.CompatibilityUtil;
 import com.github.rumsfield.konquest.utility.MessagePath;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.inventory.ItemFlag;
@@ -58,23 +59,13 @@ public class PlayerIcon implements MenuIcon {
 
 	@Override
 	public ItemStack getItem() {
-		ItemStack item = Konquest.getInstance().getPlayerHead(player);
-		ItemMeta meta = item.getItemMeta();
-		assert meta != null;
 		List<String> loreList = new ArrayList<>();
 		String lastOnlineFormat = Konquest.getLastSeenFormat(player);
 		loreList.add(propertyColor+MessagePath.LABEL_PLAYER.getMessage());
 		loreList.add(loreColor+ MessagePath.LABEL_LAST_SEEN.getMessage(valueColor+lastOnlineFormat));
 		loreList.addAll(lore);
-		for(ItemFlag flag : ItemFlag.values()) {
-			if(!meta.hasItemFlag(flag)) {
-				meta.addItemFlags(flag);
-			}
-		}
-		meta.setDisplayName(getName());
-		meta.setLore(loreList);
-		item.setItemMeta(meta);
-		return item;
+		String name = getName();
+		return CompatibilityUtil.buildItem(null, name, loreList, false, player);
 	}
 	
 	@Override

--- a/core/src/main/java/com/github/rumsfield/konquest/display/icon/PrefixCustomIcon.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/display/icon/PrefixCustomIcon.java
@@ -9,6 +9,7 @@ import org.bukkit.inventory.ItemFlag;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 
+import java.util.Collections;
 import java.util.List;
 
 public class PrefixCustomIcon implements MenuIcon {
@@ -28,25 +29,14 @@ public class PrefixCustomIcon implements MenuIcon {
 	}
 	
 	private ItemStack initItem() {
-		ItemStack item = new ItemStack(Material.IRON_BARS);
-		ItemMeta meta = item.getItemMeta();
-		assert meta != null;
+		Material material = Material.IRON_BARS;
+		boolean isProtected = false;
 		if(isClickable) {
-			meta.addEnchant(CompatibilityUtil.getProtectionEnchantment(), 1, true);
+			isProtected = true;
+			material = Material.GOLD_BLOCK;
 		}
-		for(ItemFlag flag : ItemFlag.values()) {
-			if(!meta.hasItemFlag(flag)) {
-				meta.addItemFlags(flag);
-			}
-		}
-		if(isClickable) {
-			item.setType(Material.GOLD_BLOCK);
-		}
-		String displayName = ChatUtil.parseHex(prefix.getName());
-		meta.setDisplayName(displayName);
-		meta.setLore(lore);
-		item.setItemMeta(meta);
-		return item;
+		String name = ChatUtil.parseHex(prefix.getName());
+		return CompatibilityUtil.buildItem(material, name, Collections.emptyList(), isProtected);
 	}
 	
 	public KonCustomPrefix getPrefix() {

--- a/core/src/main/java/com/github/rumsfield/konquest/display/icon/PrefixCustomIcon.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/display/icon/PrefixCustomIcon.java
@@ -2,6 +2,7 @@ package com.github.rumsfield.konquest.display.icon;
 
 import com.github.rumsfield.konquest.model.KonCustomPrefix;
 import com.github.rumsfield.konquest.utility.ChatUtil;
+import com.github.rumsfield.konquest.utility.CompatibilityUtil;
 import org.bukkit.Material;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.inventory.ItemFlag;
@@ -31,7 +32,7 @@ public class PrefixCustomIcon implements MenuIcon {
 		ItemMeta meta = item.getItemMeta();
 		assert meta != null;
 		if(isClickable) {
-			meta.addEnchant(Enchantment.PROTECTION_ENVIRONMENTAL, 1, true);
+			meta.addEnchant(CompatibilityUtil.getProtectionEnchantment(), 1, true);
 		}
 		for(ItemFlag flag : ItemFlag.values()) {
 			if(!meta.hasItemFlag(flag)) {

--- a/core/src/main/java/com/github/rumsfield/konquest/display/icon/PrefixIcon.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/display/icon/PrefixIcon.java
@@ -1,6 +1,8 @@
 package com.github.rumsfield.konquest.display.icon;
 
 import com.github.rumsfield.konquest.model.KonPrefixType;
+import com.github.rumsfield.konquest.utility.ChatUtil;
+import com.github.rumsfield.konquest.utility.CompatibilityUtil;
 import com.github.rumsfield.konquest.utility.MessagePath;
 import net.md_5.bungee.api.ChatColor;
 import org.bukkit.Material;
@@ -8,6 +10,7 @@ import org.bukkit.inventory.ItemFlag;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 
+import java.util.Collections;
 import java.util.List;
 
 public class PrefixIcon implements MenuIcon {
@@ -34,28 +37,20 @@ public class PrefixIcon implements MenuIcon {
 	}
 	
 	private ItemStack initItem() {
-		ItemStack item = new ItemStack(Material.IRON_BARS);
-		ItemMeta meta = item.getItemMeta();
-		assert meta != null;
-		for(ItemFlag flag : ItemFlag.values()) {
-			if(!meta.hasItemFlag(flag)) {
-				meta.addItemFlags(flag);
-			}
-		}
+		Material material = Material.IRON_BARS;
 		ChatColor iconColor = ChatColor.GRAY;
+		String name;
 		if(isClickable) {
-			item.setType(prefix.category().getMaterial());
+			material = prefix.category().getMaterial();
 			iconColor = ChatColor.DARK_GREEN;
 		}
 		if(action.equals(PrefixIconAction.DISABLE_PREFIX)) {
-			item.setType(Material.MILK_BUCKET);
-			meta.setDisplayName(ChatColor.DARK_RED+MessagePath.MENU_PREFIX_DISABLE.getMessage());
+			material = Material.MILK_BUCKET;
+			name = ChatColor.DARK_RED+MessagePath.MENU_PREFIX_DISABLE.getMessage();
 		} else {
-			meta.setDisplayName(iconColor+prefix.getName());
+			name = iconColor+prefix.getName();
 		}
-		meta.setLore(lore);
-		item.setItemMeta(meta);
-		return item;
+		return CompatibilityUtil.buildItem(material, name, lore);
 	}
 	
 	public PrefixIconAction getAction() {

--- a/core/src/main/java/com/github/rumsfield/konquest/display/icon/ProfessionIcon.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/display/icon/ProfessionIcon.java
@@ -1,6 +1,7 @@
 package com.github.rumsfield.konquest.display.icon;
 
 import com.github.rumsfield.konquest.Konquest;
+import com.github.rumsfield.konquest.utility.CompatibilityUtil;
 import org.bukkit.Material;
 import org.bukkit.entity.Villager;
 import org.bukkit.inventory.ItemFlag;
@@ -41,18 +42,7 @@ public class ProfessionIcon implements MenuIcon {
 
 	@Override
 	public ItemStack getItem() {
-		ItemStack item = new ItemStack(Konquest.getProfessionMaterial(profession),1);
-		ItemMeta meta = item.getItemMeta();
-		assert meta != null;
-		for(ItemFlag flag : ItemFlag.values()) {
-			if(!meta.hasItemFlag(flag)) {
-				meta.addItemFlags(flag);
-			}
-		}
-		meta.setDisplayName(getName());
-		meta.setLore(lore);
-		item.setItemMeta(meta);
-		return item;
+		return CompatibilityUtil.buildItem(Konquest.getProfessionMaterial(profession), getName(), lore);
 	}
 
 	@Override

--- a/core/src/main/java/com/github/rumsfield/konquest/display/icon/ShieldIcon.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/display/icon/ShieldIcon.java
@@ -38,18 +38,9 @@ public class ShieldIcon implements MenuIcon {
 	}
 	
 	private ItemStack initItem() {
-		Material mat = Material.SHIELD;
+		Material material = Material.SHIELD;
 		if(!isAvailable) {
-			mat = Material.IRON_BARS;
-		}
-		ItemStack item = new ItemStack(mat,1);
-		ItemMeta meta = item.getItemMeta();
-		assert meta != null;
-		meta.addEnchant(CompatibilityUtil.getProtectionEnchantment(), 1, true);
-		for(ItemFlag flag : ItemFlag.values()) {
-			if(!meta.hasItemFlag(flag)) {
-				meta.addItemFlags(flag);
-			}
+			material = Material.IRON_BARS;
 		}
 		int totalCost = shield.getCost() + (shield.getCostPerResident()*population) + (shield.getCostPerLand()*land);
 		List<String> loreList = new ArrayList<>();
@@ -58,10 +49,8 @@ public class ShieldIcon implements MenuIcon {
     	if(isAvailable) {
     		loreList.add(hintColor+MessagePath.MENU_SHIELD_HINT.getMessage());
     	}
-    	meta.setDisplayName(ChatColor.GOLD+shield.getId()+" "+MessagePath.LABEL_SHIELD.getMessage());
-		meta.setLore(loreList);
-		item.setItemMeta(meta);
-		return item;
+		String name = ChatColor.GOLD+shield.getId()+" "+MessagePath.LABEL_SHIELD.getMessage();
+		return CompatibilityUtil.buildItem(material, name, loreList, true);
 	}
 	
 	public KonShield getShield() {

--- a/core/src/main/java/com/github/rumsfield/konquest/display/icon/ShieldIcon.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/display/icon/ShieldIcon.java
@@ -3,6 +3,7 @@ package com.github.rumsfield.konquest.display.icon;
 import com.github.rumsfield.konquest.Konquest;
 import com.github.rumsfield.konquest.manager.DisplayManager;
 import com.github.rumsfield.konquest.model.KonShield;
+import com.github.rumsfield.konquest.utility.CompatibilityUtil;
 import com.github.rumsfield.konquest.utility.MessagePath;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
@@ -44,7 +45,7 @@ public class ShieldIcon implements MenuIcon {
 		ItemStack item = new ItemStack(mat,1);
 		ItemMeta meta = item.getItemMeta();
 		assert meta != null;
-		meta.addEnchant(Enchantment.PROTECTION_ENVIRONMENTAL, 1, true);
+		meta.addEnchant(CompatibilityUtil.getProtectionEnchantment(), 1, true);
 		for(ItemFlag flag : ItemFlag.values()) {
 			if(!meta.hasItemFlag(flag)) {
 				meta.addItemFlags(flag);

--- a/core/src/main/java/com/github/rumsfield/konquest/display/icon/TemplateIcon.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/display/icon/TemplateIcon.java
@@ -2,6 +2,7 @@ package com.github.rumsfield.konquest.display.icon;
 
 import com.github.rumsfield.konquest.manager.DisplayManager;
 import com.github.rumsfield.konquest.model.KonMonumentTemplate;
+import com.github.rumsfield.konquest.utility.CompatibilityUtil;
 import com.github.rumsfield.konquest.utility.MessagePath;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
@@ -52,14 +53,6 @@ public class TemplateIcon implements MenuIcon {
 
 	@Override
 	public ItemStack getItem() {
-		ItemStack item = new ItemStack(Material.CRAFTING_TABLE,1);
-		ItemMeta meta = item.getItemMeta();
-		assert meta != null;
-		for(ItemFlag flag : ItemFlag.values()) {
-			if(!meta.hasItemFlag(flag)) {
-				meta.addItemFlags(flag);
-			}
-		}
 		List<String> itemLore = new ArrayList<>();
 		if(template != null) {
 			if(!template.isValid()) {
@@ -74,10 +67,8 @@ public class TemplateIcon implements MenuIcon {
 			itemLore.add(loreColor+MessagePath.LABEL_LOOT_CHESTS.getMessage()+": "+valueColor+template.getNumLootChests());
 		}
 		itemLore.addAll(lore);
-		meta.setDisplayName(contextColor+MessagePath.LABEL_MONUMENT_TEMPLATE.getMessage());
-		meta.setLore(itemLore);
-		item.setItemMeta(meta);
-		return item;
+		String name = contextColor+MessagePath.LABEL_MONUMENT_TEMPLATE.getMessage();
+		return CompatibilityUtil.buildItem(Material.CRAFTING_TABLE, name, itemLore);
 	}
 
 	@Override

--- a/core/src/main/java/com/github/rumsfield/konquest/display/icon/TownIcon.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/display/icon/TownIcon.java
@@ -3,6 +3,7 @@ package com.github.rumsfield.konquest.display.icon;
 import com.github.rumsfield.konquest.api.model.KonquestTerritoryType;
 import com.github.rumsfield.konquest.manager.DisplayManager;
 import com.github.rumsfield.konquest.model.KonTown;
+import com.github.rumsfield.konquest.utility.CompatibilityUtil;
 import com.github.rumsfield.konquest.utility.MessagePath;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
@@ -74,7 +75,7 @@ public class TownIcon implements MenuIcon {
 			loreList.add(propertyColor+MessagePath.LABEL_ARMOR.getMessage());
 		}
 		if(town.isShielded()) {
-			meta.addEnchant(Enchantment.PROTECTION_ENVIRONMENTAL, 1, true);
+			meta.addEnchant(CompatibilityUtil.getProtectionEnchantment(), 1, true);
 			loreList.add(propertyColor+MessagePath.LABEL_SHIELD.getMessage());
 		}
 		// Lore

--- a/core/src/main/java/com/github/rumsfield/konquest/display/icon/TownIcon.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/display/icon/TownIcon.java
@@ -46,10 +46,8 @@ public class TownIcon implements MenuIcon {
 		} else if(town.isArmored()) {
 			material = Material.STONE_BRICKS;
 		}
-		ItemStack item = new ItemStack(material,1);
-		ItemMeta meta = item.getItemMeta();
-		assert meta != null;
 		// Add applicable labels
+		boolean isProtected = false;
 		List<String> loreList = new ArrayList<>();
 		// Alerts
 		if(town.getTerritoryType().equals(KonquestTerritoryType.CAPITAL) &&
@@ -75,22 +73,15 @@ public class TownIcon implements MenuIcon {
 			loreList.add(propertyColor+MessagePath.LABEL_ARMOR.getMessage());
 		}
 		if(town.isShielded()) {
-			meta.addEnchant(CompatibilityUtil.getProtectionEnchantment(), 1, true);
+			isProtected = true;
 			loreList.add(propertyColor+MessagePath.LABEL_SHIELD.getMessage());
 		}
 		// Lore
 		loreList.add(loreColor+MessagePath.LABEL_POPULATION.getMessage() + ": " + valueColor + town.getNumResidents());
 		loreList.add(loreColor+MessagePath.LABEL_LAND.getMessage() + ": " + valueColor + town.getChunkList().size());
 		loreList.addAll(lore);
-		for(ItemFlag flag : ItemFlag.values()) {
-			if(!meta.hasItemFlag(flag)) {
-				meta.addItemFlags(flag);
-			}
-		}
-		meta.setDisplayName(contextColor+town.getName());
-		meta.setLore(loreList);
-		item.setItemMeta(meta);
-		return item;
+		String name = contextColor+town.getName();
+		return CompatibilityUtil.buildItem(material, name, loreList, isProtected);
 	}
 	
 	public KonTown getTown() {

--- a/core/src/main/java/com/github/rumsfield/konquest/display/icon/UpgradeIcon.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/display/icon/UpgradeIcon.java
@@ -3,6 +3,7 @@ package com.github.rumsfield.konquest.display.icon;
 import com.github.rumsfield.konquest.Konquest;
 import com.github.rumsfield.konquest.manager.DisplayManager;
 import com.github.rumsfield.konquest.model.KonUpgrade;
+import com.github.rumsfield.konquest.utility.CompatibilityUtil;
 import com.github.rumsfield.konquest.utility.MessagePath;
 import org.bukkit.ChatColor;
 import org.bukkit.inventory.ItemFlag;
@@ -34,14 +35,6 @@ public class UpgradeIcon implements MenuIcon{
 	}
 
 	private ItemStack initItem() {
-		ItemStack item = new ItemStack(upgrade.getIcon(),1);
-		ItemMeta meta = item.getItemMeta();
-		assert meta != null;
-		for(ItemFlag flag : ItemFlag.values()) {
-			if(!meta.hasItemFlag(flag)) {
-				meta.addItemFlags(flag);
-			}
-		}
 		List<String> loreList = new ArrayList<>();
 		loreList.add(loreColor+MessagePath.LABEL_LEVEL.getMessage()+" "+level);
 		loreList.add(loreColor+MessagePath.LABEL_COST.getMessage()+": "+valueColor+cost);
@@ -49,10 +42,8 @@ public class UpgradeIcon implements MenuIcon{
 		for(String line : Konquest.stringPaginate(upgrade.getLevelDescription(level))) {
 			loreList.add(loreColor+line);
 		}
-		meta.setDisplayName(ChatColor.GOLD+upgrade.getDescription());
-		meta.setLore(loreList);
-		item.setItemMeta(meta);
-		return item;
+		String name = ChatColor.GOLD+upgrade.getDescription();
+		return CompatibilityUtil.buildItem(upgrade.getIcon(), name, loreList);
 	}
 	
 	public KonUpgrade getUpgrade() {

--- a/core/src/main/java/com/github/rumsfield/konquest/listener/EntityListener.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/listener/EntityListener.java
@@ -9,10 +9,7 @@ import com.github.rumsfield.konquest.model.*;
 import com.github.rumsfield.konquest.manager.KingdomManager;
 import com.github.rumsfield.konquest.manager.PlayerManager;
 import com.github.rumsfield.konquest.manager.TerritoryManager;
-import com.github.rumsfield.konquest.utility.ChatUtil;
-import com.github.rumsfield.konquest.utility.CorePath;
-import com.github.rumsfield.konquest.utility.CustomCommandPath;
-import com.github.rumsfield.konquest.utility.MessagePath;
+import com.github.rumsfield.konquest.utility.*;
 
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
@@ -434,7 +431,7 @@ public class EntityListener implements Listener {
 		// Checks
 		if(event.isCancelled()) return;
     	if(konquest.isWorldIgnored(event.getEntity().getLocation())) return;
-		boolean isProtectedType = event.getEntityType().equals(EntityType.DROPPED_ITEM) ||
+		boolean isProtectedType = event.getEntityType().equals(CompatibilityUtil.getEntityType("item")) ||
 				event.getEntityType().equals(EntityType.ARROW) ||
 				event.getEntityType().equals(EntityType.SPECTRAL_ARROW);
 		if(!isProtectedType) return;
@@ -964,7 +961,7 @@ public class EntityListener implements Listener {
     public void onProjectileLaunch(ProjectileLaunchEvent event) {
 		if(konquest.isWorldIgnored(event.getEntity().getWorld())) return;
 		ProjectileSource source = event.getEntity().getShooter();
-		if(event.getEntityType().equals(EntityType.SPLASH_POTION) && source instanceof Player) {
+		if(event.getEntityType().equals(CompatibilityUtil.getEntityType("potion")) && source instanceof Player) {
 			Player bukkitPlayer = (Player)source;
 			KonPlayer player = playerManager.getPlayer(bukkitPlayer);
 			if(player != null) {
@@ -989,7 +986,7 @@ public class EntityListener implements Listener {
 		if(konquest.isWorldIgnored(event.getEntity().getWorld())) return;
 		ProjectileSource source = event.getEntity().getShooter();
 		// Check for splash potion thrown by player
-		if(!(event.getEntityType().equals(EntityType.SPLASH_POTION) && source instanceof Player)) return;
+		if(!(event.getEntityType().equals(CompatibilityUtil.getEntityType("potion")) && source instanceof Player)) return;
 		Player bukkitPlayer = (Player)source;
 		KonPlayer player = playerManager.getPlayer(bukkitPlayer);
 		// Check for claimed territory

--- a/core/src/main/java/com/github/rumsfield/konquest/listener/InventoryListener.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/listener/InventoryListener.java
@@ -7,10 +7,7 @@ import com.github.rumsfield.konquest.api.model.KonquestTerritoryType;
 import com.github.rumsfield.konquest.manager.KingdomManager;
 import com.github.rumsfield.konquest.manager.PlayerManager;
 import com.github.rumsfield.konquest.model.*;
-import com.github.rumsfield.konquest.utility.ChatUtil;
-import com.github.rumsfield.konquest.utility.CorePath;
-import com.github.rumsfield.konquest.utility.CustomCommandPath;
-import com.github.rumsfield.konquest.utility.MessagePath;
+import com.github.rumsfield.konquest.utility.*;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -33,6 +30,8 @@ import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.MerchantInventory;
 import org.bukkit.inventory.SmithingInventory;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.Map;
 
 public class InventoryListener implements Listener {
@@ -209,7 +208,7 @@ public class InventoryListener implements Listener {
 		int slot = event.getRawSlot();
 		Player bukkitPlayer = (Player) event.getWhoClicked();
 		KonPlayer player = konquest.getPlayerManager().getPlayer(bukkitPlayer);
-		if(player == null || slot >= event.getView().getTopInventory().getSize()) return;
+		if(player == null || slot >= CompatibilityUtil.getTopInventory(event).getSize()) return;
 		event.setResult(Event.Result.DENY);
 		event.setCancelled(true);
 		if(event.getClick().equals(ClickType.LEFT) || event.getClick().equals(ClickType.RIGHT)) {
@@ -252,14 +251,13 @@ public class InventoryListener implements Listener {
 		// Prevent placing items into loot chests
 		if(event.isCancelled()) return;
 		if(event.getClickedInventory() == null) return;
-		if(!event.getView().getTopInventory().getType().equals(InventoryType.CHEST)) return;
-		Location inventoryLocation = event.getView().getTopInventory().getLocation();
+		if(!CompatibilityUtil.getTopInventory(event).getType().equals(InventoryType.CHEST)) return;
+		Location inventoryLocation = CompatibilityUtil.getTopInventory(event).getLocation();
 		if(inventoryLocation == null) return;
 		// Check for ignored world
 		if(konquest.isWorldIgnored(inventoryLocation)) return;
-		//ChatUtil.printDebug("Inventory clicked on raw slot "+event.getRawSlot()+"/"+event.getView().getTopInventory().getSize()+", action "+event.getAction());
 		// Check if the raw slot index is within the chest inventory
-		if(event.getRawSlot() < event.getView().getTopInventory().getSize()) {
+		if(event.getRawSlot() < CompatibilityUtil.getTopInventory(event).getSize()) {
 			// When clicking in the top (chest) inventory, only allow pickup and shift-click of items into bottom.
 			if(event.getAction().equals(InventoryAction.PICKUP_ALL) || event.getAction().equals(InventoryAction.MOVE_TO_OTHER_INVENTORY)) {
 				//ChatUtil.printDebug("Ignored top inventory");
@@ -283,7 +281,7 @@ public class InventoryListener implements Listener {
 	public void onLootChestDrag(InventoryDragEvent event) {
 		// Prevent dragging items into loot chests
 		if(event.isCancelled()) return;
-		if(!event.getView().getTopInventory().getType().equals(InventoryType.CHEST)) return;
+		if(!CompatibilityUtil.getTopInventory(event).getType().equals(InventoryType.CHEST)) return;
 		Location inventoryLocation = event.getInventory().getLocation();
 		if(inventoryLocation == null) return;
 		// Check for ignored world
@@ -291,7 +289,7 @@ public class InventoryListener implements Listener {
 		// Check if any raw slot index is within the chest inventory
 		boolean isInTop = false;
 		for(int slot : event.getRawSlots()) {
-			if(slot < event.getView().getTopInventory().getSize()) {
+			if(slot < CompatibilityUtil.getTopInventory(event).getSize()) {
 				isInTop = true;
 				break;
 			}

--- a/core/src/main/java/com/github/rumsfield/konquest/manager/KingdomManager.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/manager/KingdomManager.java
@@ -51,7 +51,7 @@ public class KingdomManager implements KonquestKingdomManager, Timeable {
 	private int exileCooldownSeconds;
 	private final HashMap<UUID,Integer> joinPlayerCooldowns;
 	private final HashMap<UUID,Integer> exilePlayerCooldowns;
-	private ArrayList<DiplomacyTicket> diplomacyTickets;
+	private final ArrayList<DiplomacyTicket> diplomacyTickets;
 	private boolean isKingdomDataNull;
 
 	// Config Settings
@@ -1013,6 +1013,7 @@ public class KingdomManager implements KonquestKingdomManager, Timeable {
 	 * (Optionally) Removes all favor.
 	 * (Optionally) Resets their exileKingdom to Barbarians, making them look like a new player to Konquest.
 	 * Applies exile cool-down timer.
+	 * Method call setBedSpawnLocation() is known to be deprecated.
 	 * 
 	 * @param id The UUID of the player who is being exiled
 	 * @param teleport Teleport the player based on Konquest configuration when true
@@ -1028,6 +1029,7 @@ public class KingdomManager implements KonquestKingdomManager, Timeable {
 	 * 				9   - Unknown player ID
 	 *             -1 	- internal error
 	 */
+	@SuppressWarnings("deprecation")
 	public int exilePlayerBarbarian(UUID id, boolean teleport, boolean clearStats, boolean isFull, boolean force) {
 		
 		// Determine offline/online player
@@ -3428,7 +3430,7 @@ public class KingdomManager implements KonquestKingdomManager, Timeable {
 	}
 	
 	private void makeTownNerfs() {
-		townNerfs.put(PotionEffectType.SLOW_DIGGING, 0);
+		townNerfs.put(CompatibilityUtil.getMiningFatigue(), 0);
 	}
 	
 	public void applyTownNerf(KonPlayer player, KonTown town) {

--- a/core/src/main/java/com/github/rumsfield/konquest/manager/KingdomManager.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/manager/KingdomManager.java
@@ -1919,6 +1919,12 @@ public class KingdomManager implements KonquestKingdomManager, Timeable {
 			return false;
 		}
 
+		// Check for self relation
+		if(kingdom.equals(otherKingdom)) {
+			ChatUtil.sendError(messageSender,MessagePath.GENERIC_ERROR_NO_ALLOW.getMessage());
+			return false;
+		}
+
 		// Check cost
 		double costRelation = getRelationCost(relation);
 		if(costRelation > 0 && !isAdmin && payPlayer != null) {

--- a/core/src/main/java/com/github/rumsfield/konquest/manager/LootManager.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/manager/LootManager.java
@@ -166,9 +166,10 @@ public class LootManager implements Timeable{
 				// Add loot table entry
 				ItemStack potion = new ItemStack(Material.POTION, 1);
 				PotionMeta meta = CompatibilityUtil.setPotionData((PotionMeta) potion.getItemMeta(), potionType, itemExtended, itemUpgraded);
+				assert meta != null;
 				potion.setItemMeta(meta);
 				result.put(potion, itemWeight);
-				ChatUtil.printDebug("  Added loot path "+pathName+" potion "+potionName+" with extended "+itemExtended+", upgraded "+itemUpgraded+", weight "+itemWeight);
+				ChatUtil.printDebug("  Added loot path "+pathName+" potion "+meta.getBasePotionType()+" with extended "+itemExtended+", upgraded "+itemUpgraded+", weight "+itemWeight);
 			}
 		}
 		return result;

--- a/core/src/main/java/com/github/rumsfield/konquest/manager/LootManager.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/manager/LootManager.java
@@ -185,7 +185,7 @@ public class LootManager implements Timeable{
 			status = true;
 			int itemLevel = 0;
 			int itemWeight = 0;
-			bookType = getEnchantment(enchantName);
+			bookType = CompatibilityUtil.getEnchantment(enchantName);
 			if(bookType == null) {
 				ChatUtil.printConsoleError("Invalid loot enchantment \""+enchantName+"\" given in loot.yml path "+pathName+", skipping this enchantment.");
 				status = false;
@@ -223,7 +223,7 @@ public class LootManager implements Timeable{
 				enchantMeta.addStoredEnchant(bookType, itemLevel, true);
 				enchantBook.setItemMeta(enchantMeta);
 				result.put(enchantBook, itemWeight);
-				ChatUtil.printDebug("  Added loot path "+pathName+" enchant "+enchantName+" with level "+itemLevel+", weight "+itemWeight);
+				ChatUtil.printDebug("  Added loot path "+pathName+" enchant "+bookType.getKey().toString()+" with level "+itemLevel+", weight "+itemWeight);
 			}
 		}
 		return result;
@@ -359,16 +359,6 @@ public class LootManager implements Timeable{
 	/*
 	 * Common
 	 */
-
-	private Enchantment getEnchantment(String fieldName) {
-		Enchantment result = null;
-		try {
-			Class<?> c = Enchantment.class;
-			Field field = c.getDeclaredField(fieldName);
-			result = (Enchantment)field.get(null);
-		} catch(NoSuchFieldException | SecurityException | IllegalArgumentException | IllegalAccessException ignored) {}
-		return result;
-	}
 
 	private void clearUpperInventory(Inventory inventory) {
 		inventory.clear();

--- a/core/src/main/java/com/github/rumsfield/konquest/manager/LootManager.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/manager/LootManager.java
@@ -169,7 +169,7 @@ public class LootManager implements Timeable{
 				assert meta != null;
 				potion.setItemMeta(meta);
 				result.put(potion, itemWeight);
-				ChatUtil.printDebug("  Added loot path "+pathName+" potion "+meta.getBasePotionType()+" with extended "+itemExtended+", upgraded "+itemUpgraded+", weight "+itemWeight);
+				ChatUtil.printDebug("  Added loot path "+pathName+" potion "+potionType+" with extended "+itemExtended+", upgraded "+itemUpgraded+", weight "+itemWeight);
 			}
 		}
 		return result;

--- a/core/src/main/java/com/github/rumsfield/konquest/manager/LootManager.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/manager/LootManager.java
@@ -165,14 +165,7 @@ public class LootManager implements Timeable{
 			if(status && itemWeight > 0) {
 				// Add loot table entry
 				ItemStack potion = new ItemStack(Material.POTION, 1);
-				PotionMeta meta;
-				meta = (PotionMeta) potion.getItemMeta();
-				try {
-					meta.setBasePotionData(new PotionData(potionType, itemExtended, itemUpgraded));
-				} catch(IllegalArgumentException e) {
-					meta.setBasePotionData(new PotionData(potionType, false, false));
-					ChatUtil.printConsoleError("Invalid options extended="+itemExtended+", upgraded="+itemUpgraded+" for potion "+potionName+" in loot.yml path "+pathName);
-				}
+				PotionMeta meta = CompatibilityUtil.setPotionData((PotionMeta) potion.getItemMeta(), potionType, itemExtended, itemUpgraded);
 				potion.setItemMeta(meta);
 				result.put(potion, itemWeight);
 				ChatUtil.printDebug("  Added loot path "+pathName+" potion "+potionName+" with extended "+itemExtended+", upgraded "+itemUpgraded+", weight "+itemWeight);

--- a/core/src/main/java/com/github/rumsfield/konquest/model/KonPlayer.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/model/KonPlayer.java
@@ -1,9 +1,7 @@
 package com.github.rumsfield.konquest.model;
 
 import com.github.rumsfield.konquest.api.model.KonquestPlayer;
-import com.github.rumsfield.konquest.utility.ChatUtil;
-import com.github.rumsfield.konquest.utility.MessagePath;
-import com.github.rumsfield.konquest.utility.Timeable;
+import com.github.rumsfield.konquest.utility.*;
 import com.github.rumsfield.konquest.utility.Timer;
 import org.bukkit.*;
 import org.bukkit.block.Block;
@@ -401,7 +399,7 @@ public class KonPlayer extends KonOfflinePlayer implements KonquestPlayer, Timea
 			for(Location loc : borderMap.keySet()) {
 				if(loc.getWorld().equals(getBukkitPlayer().getWorld()) && loc.distance(getBukkitPlayer().getLocation()) < 12) {
 					particleColor = borderMap.get(loc);
-					getBukkitPlayer().spawnParticle(Particle.REDSTONE, loc, 2, 0.25, 0, 0.25, new Particle.DustOptions(particleColor,1));
+					getBukkitPlayer().spawnParticle(CompatibilityUtil.getParticle("dust"), loc, 2, 0.25, 0, 0.25, new Particle.DustOptions(particleColor,1));
 				}
 			}
 			for(Location loc : borderPlotMap.keySet()) {
@@ -410,13 +408,13 @@ public class KonPlayer extends KonOfflinePlayer implements KonquestPlayer, Timea
 					double red = particleColor.getRed() / 255D;
 					double green = particleColor.getGreen() / 255D;
 					double blue = particleColor.getBlue() / 255D;
-					getBukkitPlayer().spawnParticle(Particle.SPELL_MOB_AMBIENT, loc, 0, red, green, blue, 1);
+					getBukkitPlayer().spawnParticle(CompatibilityUtil.getParticle("spell"), loc, 0, red, green, blue, 1);
 				}
 			}
 		} else if(taskID == monumentTemplateLoopTimer.getTaskID()) {
 			updateMonumentTemplateBoundary();
 			for(Location loc : monumentTemplateBoundary.keySet()) {
-				getBukkitPlayer().spawnParticle(Particle.REDSTONE, loc, 1, 0, 0, 0, new Particle.DustOptions(monumentTemplateBoundary.get(loc),1));
+				getBukkitPlayer().spawnParticle(CompatibilityUtil.getParticle("dust"), loc, 1, 0, 0, 0, new Particle.DustOptions(monumentTemplateBoundary.get(loc),1));
 			}
 		} else if(taskID == monumentShowLoopTimer.getTaskID()) {
 			if(monumentShowLoopCount <= 0) {
@@ -425,7 +423,7 @@ public class KonPlayer extends KonOfflinePlayer implements KonquestPlayer, Timea
 			} else {
 				monumentShowLoopCount--;
 				for(Location loc : monumentShowBoundary) {
-					getBukkitPlayer().spawnParticle(Particle.REDSTONE, loc, 1, 0, 0, 0, new Particle.DustOptions(Color.LIME,1));
+					getBukkitPlayer().spawnParticle(CompatibilityUtil.getParticle("dust"), loc, 1, 0, 0, 0, new Particle.DustOptions(Color.LIME,1));
 				}
 			}
 		} else if(taskID == combatTagTimer.getTaskID()) {

--- a/core/src/main/java/com/github/rumsfield/konquest/model/KonPlayer.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/model/KonPlayer.java
@@ -405,10 +405,7 @@ public class KonPlayer extends KonOfflinePlayer implements KonquestPlayer, Timea
 			for(Location loc : borderPlotMap.keySet()) {
 				if(loc.getWorld().equals(getBukkitPlayer().getWorld()) && loc.distance(getBukkitPlayer().getLocation()) < 12) {
 					particleColor = borderPlotMap.get(loc);
-					double red = particleColor.getRed() / 255D;
-					double green = particleColor.getGreen() / 255D;
-					double blue = particleColor.getBlue() / 255D;
-					getBukkitPlayer().spawnParticle(CompatibilityUtil.getParticle("spell"), loc, 0, red, green, blue, 1);
+					CompatibilityUtil.playerSpawnEffect(getBukkitPlayer(),loc,particleColor);
 				}
 			}
 		} else if(taskID == monumentTemplateLoopTimer.getTaskID()) {

--- a/core/src/main/java/com/github/rumsfield/konquest/nms/Handler_1_16_R3.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/nms/Handler_1_16_R3.java
@@ -18,8 +18,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.Collection;
 import java.util.List;
 
-public class
-Handler_1_16_R3 implements VersionHandler {
+public class Handler_1_16_R3 implements VersionHandler {
 
 	public Handler_1_16_R3() {}
 	

--- a/core/src/main/java/com/github/rumsfield/konquest/nms/Handler_1_16_R3.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/nms/Handler_1_16_R3.java
@@ -18,7 +18,8 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.Collection;
 import java.util.List;
 
-public class Handler_1_16_R3 implements VersionHandler {
+public class
+Handler_1_16_R3 implements VersionHandler {
 
 	public Handler_1_16_R3() {}
 	

--- a/core/src/main/java/com/github/rumsfield/konquest/utility/ChatUtil.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/utility/ChatUtil.java
@@ -431,5 +431,15 @@ public class ChatUtil {
 			}
 		}
 	}
+
+	public static void showStackTrace() {
+		// Get stack trace
+		for (StackTraceElement element : Thread.currentThread().getStackTrace()) {
+			String traceStr = element.toString();
+			if (traceStr.contains("Konquest")) {
+				Bukkit.getServer().getConsoleSender().sendMessage(element.toString());
+			}
+		}
+	}
 	
 }

--- a/core/src/main/java/com/github/rumsfield/konquest/utility/ChatUtil.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/utility/ChatUtil.java
@@ -403,20 +403,20 @@ public class ChatUtil {
 	}
 
 	public static void sendKonBlockedProtectionTitle(KonPlayer player) {
-		printDebug("Blocked Protection by player "+player.getBukkitPlayer().getName());
-		showDebugStackTrace();
+		//printDebug("Blocked Protection by player "+player.getBukkitPlayer().getName());
+		//showDebugStackTrace();
 		sendKonPriorityTitle(player, "", Konquest.blockedProtectionColor+MessagePath.PROTECTION_ERROR_BLOCKED.getMessage(), 1, 10, 10);
 	}
 
 	public static void sendKonBlockedFlagTitle(KonPlayer player) {
-		printDebug("Blocked Flag by player "+player.getBukkitPlayer().getName());
-		showDebugStackTrace();
+		//printDebug("Blocked Flag by player "+player.getBukkitPlayer().getName());
+		//showDebugStackTrace();
 		sendKonPriorityTitle(player, "", Konquest.blockedFlagColor+MessagePath.PROTECTION_ERROR_BLOCKED.getMessage(), 1, 10, 10);
 	}
 
 	public static void sendKonBlockedShieldTitle(KonPlayer player) {
-		printDebug("Blocked Shield by player "+player.getBukkitPlayer().getName());
-		showDebugStackTrace();
+		//printDebug("Blocked Shield by player "+player.getBukkitPlayer().getName());
+		//showDebugStackTrace();
 		sendKonPriorityTitle(player, "", Konquest.blockedShieldColor+MessagePath.PROTECTION_ERROR_BLOCKED.getMessage(), 1, 10, 10);
 	}
 

--- a/core/src/main/java/com/github/rumsfield/konquest/utility/CompatibilityUtil.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/utility/CompatibilityUtil.java
@@ -1,0 +1,247 @@
+package com.github.rumsfield.konquest.utility;
+
+import org.bukkit.Bukkit;
+import org.bukkit.NamespacedKey;
+import org.bukkit.Particle;
+import org.bukkit.Registry;
+import org.bukkit.enchantments.Enchantment;
+import org.bukkit.entity.EntityType;
+import org.bukkit.inventory.meta.PotionMeta;
+import org.bukkit.potion.PotionEffectType;
+import org.bukkit.potion.PotionType;
+
+/**
+ * This class provides static method implementations that work for the full range of supported Spigot API versions.
+ */
+public class CompatibilityUtil {
+
+    enum SpigotApiVersion {
+        INVALID,
+        V1_16_5,
+        V1_17_1,
+        V1_18_2,
+        V1_19_4,
+        V1_20_4,
+        V1_20_6,
+        V1_21_0
+    }
+
+    private static SpigotApiVersion getApiVersion() {
+        String bukkitVersion = Bukkit.getVersion();
+        if (bukkitVersion.contains("1.16.5")) {
+            return SpigotApiVersion.V1_16_5;
+        } else if (bukkitVersion.contains("1.17.1")) {
+            return SpigotApiVersion.V1_17_1;
+        } else if (bukkitVersion.contains("1.18.2")) {
+            return SpigotApiVersion.V1_18_2;
+        } else if (bukkitVersion.contains("1.19.4")) {
+            return SpigotApiVersion.V1_19_4;
+        } else if (bukkitVersion.contains("1.20.4")) {
+            return SpigotApiVersion.V1_20_4;
+        } else if (bukkitVersion.contains("1.20.6")) {
+            return SpigotApiVersion.V1_20_6;
+        } else if (bukkitVersion.contains("1.20.0")) {
+            return SpigotApiVersion.V1_21_0;
+        } else {
+            ChatUtil.printConsoleError("Failed to resolve valid API version for compatibility: "+bukkitVersion);
+            ChatUtil.showStackTrace();
+            return SpigotApiVersion.INVALID;
+        }
+    }
+
+    private static PotionType lookupPotionType(PotionType type, boolean isExtended, boolean isUpgraded) {
+        switch (type) {
+            case FIRE_RESISTANCE:
+                if (isExtended) return PotionType.LONG_FIRE_RESISTANCE;
+                break;
+            case INVISIBILITY:
+                if (isExtended) return PotionType.LONG_INVISIBILITY;
+                break;
+            case LEAPING:
+                if (isExtended) return PotionType.LONG_LEAPING;
+                if (isUpgraded) return PotionType.STRONG_LEAPING;
+                break;
+            case NIGHT_VISION:
+                if (isExtended) return PotionType.LONG_NIGHT_VISION;
+                break;
+            case POISON:
+                if (isExtended) return PotionType.LONG_POISON;
+                if (isUpgraded) return PotionType.STRONG_POISON;
+                break;
+            case REGENERATION:
+                if (isExtended) return PotionType.LONG_REGENERATION;
+                if (isUpgraded) return PotionType.STRONG_REGENERATION;
+                break;
+            case SLOW_FALLING:
+                if (isExtended) return PotionType.LONG_SLOW_FALLING;
+                break;
+            case SLOWNESS:
+                if (isExtended) return PotionType.LONG_SLOWNESS;
+                if (isUpgraded) return PotionType.STRONG_SLOWNESS;
+                break;
+            case STRENGTH:
+                if (isExtended) return PotionType.LONG_STRENGTH;
+                if (isUpgraded) return PotionType.STRONG_STRENGTH;
+                break;
+            case SWIFTNESS:
+                if (isExtended) return PotionType.LONG_SWIFTNESS;
+                if (isUpgraded) return PotionType.STRONG_SWIFTNESS;
+                break;
+            case TURTLE_MASTER:
+                if (isExtended) return PotionType.LONG_TURTLE_MASTER;
+                if (isUpgraded) return PotionType.STRONG_TURTLE_MASTER;
+                break;
+            case WATER_BREATHING:
+                if (isExtended) return PotionType.LONG_WATER_BREATHING;
+                break;
+            case WEAKNESS:
+                if (isExtended) return PotionType.LONG_WEAKNESS;
+                break;
+            case HARMING:
+                if (isUpgraded) return PotionType.STRONG_HARMING;
+                break;
+            case HEALING:
+                if (isUpgraded) return PotionType.STRONG_HEALING;
+                break;
+            default:
+                break;
+        }
+        return PotionType.AWKWARD;
+    }
+
+    /* Class Field Name Requests */
+
+    public static PotionEffectType getMiningFatigue() {
+        PotionEffectType result;
+        switch(getApiVersion()) {
+            case V1_20_6:
+            case V1_21_0:
+                result = Registry.EFFECT.get(NamespacedKey.minecraft("MINING_FATIGUE"));
+                break;
+            default:
+                result = Registry.EFFECT.get(NamespacedKey.minecraft("SLOW_DIGGING"));
+                break;
+        }
+        if (result == null) {
+            ChatUtil.printConsoleError("Failed to get Mining Fatigue PotionEffectType for Bukkit version "+Bukkit.getVersion());
+            ChatUtil.printConsole("Valid NamespacedKeys for Potion Effects are:");
+            for (PotionEffectType effect : Registry.EFFECT) {
+                ChatUtil.printConsole(effect.getKey().toString());
+            }
+        }
+        return result;
+    }
+
+    public static Enchantment getProtectionEnchantment() {
+        Enchantment result;
+        switch(getApiVersion()) {
+            case V1_20_6:
+            case V1_21_0:
+                result = Registry.ENCHANTMENT.get(NamespacedKey.minecraft("PROTECTION"));
+                break;
+            default:
+                result = Registry.ENCHANTMENT.get(NamespacedKey.minecraft("PROTECTION_ENVIRONMENTAL"));
+                break;
+        }
+        if (result == null) {
+            ChatUtil.printConsoleError("Failed to get Protection Enchantment for Bukkit version "+Bukkit.getVersion());
+            ChatUtil.printConsole("Valid NamespacedKeys for Enchantments are:");
+            for (Enchantment enchant : Registry.ENCHANTMENT) {
+                ChatUtil.printConsole(enchant.getKey().toString());
+            }
+        }
+        return result;
+    }
+
+    /* Enum Name Requests */
+
+    /**
+     * Gets the specified Particle for the correct version enum name.
+     * @param type Which Particle to get, accepted values are:
+     *             "dust"
+     *             "spell"
+     * @return The Particle enum for the correct Bukkit version
+     */
+    public static Particle getParticle(String type) {
+        try {
+            switch (getApiVersion()) {
+                case V1_20_6:
+                case V1_21_0:
+                    if (type.equals("dust")) {
+                        return Particle.valueOf("DUST");
+                    } else if (type.equals("spell")) {
+                        return Particle.valueOf("EFFECT");
+                    }
+                    break;
+                default:
+                    if (type.equals("dust")) {
+                        return Particle.valueOf("REDSTONE");
+                    } else if (type.equals("spell")) {
+                        return Particle.valueOf("SPELL_MOB_AMBIENT");
+                    }
+                    break;
+            }
+        } catch (IllegalArgumentException exception) {
+            ChatUtil.printConsoleError("Failed to get Particle for Bukkit version "+Bukkit.getVersion());
+        }
+        // default return value
+        return Particle.FLAME;
+    }
+
+    /**
+     * Gets the specified EntityType for the correct version enum name.
+     * @param type Which EntityType to get, accepted values are:
+     *             "item"
+     *             "potion"
+     * @return The EntityType enum for the correct Bukkit version
+     */
+    public static EntityType getEntityType(String type) {
+        try {
+            switch (getApiVersion()) {
+                case V1_20_6:
+                case V1_21_0:
+                    if (type.equals("item")) {
+                        return EntityType.valueOf("ITEM");
+                    } else if (type.equals("potion")) {
+                        return EntityType.valueOf("POTION");
+                    }
+                    break;
+                default:
+                    if (type.equals("item")) {
+                        return EntityType.valueOf("DROPPED_ITEM");
+                    } else if (type.equals("potion")) {
+                        return EntityType.valueOf("SPLASH_POTION");
+                    }
+                    break;
+            }
+        } catch (IllegalArgumentException exception) {
+            ChatUtil.printConsoleError("Failed to get Entity Type for Bukkit version "+Bukkit.getVersion());
+        }
+        // default return value
+        return EntityType.EGG;
+    }
+
+    /* Utility Operations */
+
+    @SuppressWarnings({"removal","deprecation"})
+    public static PotionMeta setPotionData(PotionMeta meta, PotionType type, boolean isExtended, boolean isUpgraded) {
+        switch(getApiVersion()) {
+            case V1_20_6:
+            case V1_21_0:
+                meta.setBasePotionType(lookupPotionType(type,isExtended,isUpgraded));
+                break;
+            default:
+                try {
+                    meta.setBasePotionData(new org.bukkit.potion.PotionData(type, isExtended, isUpgraded));
+                } catch(IllegalArgumentException e) {
+                    meta.setBasePotionData(new org.bukkit.potion.PotionData(type, false, false));
+                    ChatUtil.printConsoleError("Invalid options extended="+isExtended+", upgraded="+isUpgraded+" for potion "+type.name()+" in loot.yml");
+                }
+                break;
+        }
+        return meta;
+    }
+
+
+
+}

--- a/core/src/main/java/com/github/rumsfield/konquest/utility/CompatibilityUtil.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/utility/CompatibilityUtil.java
@@ -15,10 +15,101 @@ import org.bukkit.potion.PotionType;
  */
 public class CompatibilityUtil {
 
-    enum SpigotApiVersion {
+    /**
+     * Map old enchantment namespaces to new ones
+     */
+    public enum EnchantComp {
+        // Enchantment              Pre 1.20.6                      1.20.6 and later
+        // Common
+        BINDING_CURSE               ("binding_curse",               "binding_curse"),
+        CHANNELING                  ("channeling",                  "channeling"),
+        DEPTH_STRIDER               ("depth_strider",               "depth_strider"),
+        FIRE_ASPECT                 ("fire_aspect",                 "fire_aspect"),
+        FROST_WALKER                ("frost_walker",                "frost_walker"),
+        IMPALING                    ("impaling",                    "impaling"),
+        KNOCKBACK                   ("knockback",                   "knockback"),
+        LOYALTY                     ("loyalty",                     "loyalty"),
+        LURE                        ("lure",                        "lure"),
+        MENDING                     ("mending",                     "mending"),
+        MULTISHOT                   ("multishot",                   "multishot"),
+        PIERCING                    ("piercing",                    "piercing"),
+        QUICK_CHARGE                ("quick_charge",                "quick_charge"),
+        RIPTIDE                     ("riptide",                     "riptide"),
+        SILK_TOUCH                  ("silk_touch",                  "silk_touch"),
+        SOUL_SPEED                  ("soul_speed",                  "soul_speed"),
+        SWEEPING_EDGE               ("sweeping_edge",               "sweeping_edge"),
+        SWIFT_SNEAK                 ("swift_sneak",                 "swift_sneak"),
+        THORNS                      ("thorns",                      "thorns"),
+        VANISHING_CURSE             ("vanishing_curse",             "vanishing_curse"),
+
+        // 1.20.4 and earlier
+        WATER_WORKING               ("water_working",               "aqua_afinity"),
+        DAMAGE_ARTHROPODS           ("damage_arthropods",           "bane_of_arthropods"),
+        PROTECTION_EXPLOSIONS       ("protection_explosions",       "blast_protection"),
+        DIG_SPEED                   ("dig_speed",                   "efficiency"),
+        PROTECTION_FALL             ("protection_fall",             "feather_falling"),
+        PROTECTION_FIRE             ("protection_fire",             "fire_protection"),
+        ARROW_FIRE                  ("arrow_fire",                  "flame"),
+        LOOT_BONUS_BLOCKS           ("loot_bonus_blocks",           "fortune"),
+        ARROW_INFINITE              ("arrow_infinite",              "infinity"),
+        LOOT_BONUS_MOBS             ("loot_bonus_mobs",             "looting"),
+        LUCK                        ("luck",                        "luck_of_the_sea"),
+        ARROW_DAMAGE                ("arrow_damage",                "power"),
+        PROTECTION_PROJECTILE       ("protection_projectile",       "projectile_protection"),
+        PROTECTION_ENVIRONMENTAL    ("protection_environmental",    "protection"),
+        ARROW_KNOCKBACK             ("arrow_knockback",             "punch"),
+        OXYGEN                      ("oxygen",                      "respiration"),
+        DAMAGE_ALL                  ("damage_all",                  "sharpness"),
+        DAMAGE_UNDEAD               ("damage_undead",               "smite"),
+        DURABILITY                  ("durability",                  "unbreaking"),
+
+        // 1.20.6 and later
+        AQUA_AFINITY                ("water_working",               "aqua_afinity"),
+        BANE_OF_ARTHROPODS          ("damage_arthropods",           "bane_of_arthropods"),
+        BLAST_PROTECTION            ("protection_explosions",       "blast_protection"),
+        BREACH                      ("",                            "breach"),
+        DENSITY                     ("",                            "density"),
+        EFFICIENCY                  ("dig_speed",                   "efficiency"),
+        FEATHER_FALLING             ("protection_fall",             "feather_falling"),
+        FIRE_PROTECTION             ("protection_fire",             "fire_protection"),
+        FLAME                       ("arrow_fire",                  "flame"),
+        FORTUNE                     ("loot_bonus_blocks",           "fortune"),
+        INFINITY                    ("arrow_infinite",              "infinity"),
+        LOOTING                     ("loot_bonus_mobs",             "looting"),
+        LUCK_OF_THE_SEA             ("luck",                        "luck_of_the_sea"),
+        POWER                       ("arrow_damage",                "power"),
+        PROJECTILE_PROTECTION       ("protection_projectile",       "projectile_protection"),
+        PROTECTION                  ("protection_environmental",    "protection"),
+        PUNCH                       ("arrow_knockback",             "punch"),
+        RESPIRATION                 ("oxygen",                      "respiration"),
+        SHARPNESS                   ("damage_all",                  "sharpness"),
+        SMITE                       ("damage_undead",               "smite"),
+        UNBREAKING                  ("durability",                  "unbreaking"),
+        WIND_BURST                  ("",                            "wind_burst");
+
+        public final String namespace1; // Pre 1.20.6
+        public final String namespace2; // 1.20.6 and later
+
+        EnchantComp(String namespace1, String namespace2) {
+            this.namespace1 = namespace1;
+            this.namespace2 = namespace2;
+        }
+
+        public static EnchantComp getFromName(String name) {
+            for(EnchantComp enchant : EnchantComp.values()) {
+                if(enchant.toString().equalsIgnoreCase(name)) {
+                    return enchant;
+                }
+            }
+            return null;
+        }
+    }
+
+    public enum SpigotApiVersion {
         INVALID,
         V1_16_5,
         V1_17_1,
+        V1_18_1,
         V1_18_2,
         V1_19_4,
         V1_20_4,
@@ -26,12 +117,14 @@ public class CompatibilityUtil {
         V1_21_0
     }
 
-    private static SpigotApiVersion getApiVersion() {
+    public static SpigotApiVersion getApiVersion() {
         String bukkitVersion = Bukkit.getVersion();
         if (bukkitVersion.contains("1.16.5")) {
             return SpigotApiVersion.V1_16_5;
         } else if (bukkitVersion.contains("1.17.1")) {
             return SpigotApiVersion.V1_17_1;
+        } else if (bukkitVersion.contains("1.18.1")) {
+            return SpigotApiVersion.V1_18_1;
         } else if (bukkitVersion.contains("1.18.2")) {
             return SpigotApiVersion.V1_18_2;
         } else if (bukkitVersion.contains("1.19.4")) {
@@ -114,12 +207,18 @@ public class CompatibilityUtil {
     public static PotionEffectType getMiningFatigue() {
         PotionEffectType result;
         switch(getApiVersion()) {
-            case V1_20_6:
-            case V1_21_0:
-                result = Registry.EFFECT.get(NamespacedKey.minecraft("MINING_FATIGUE"));
+            case V1_16_5:
+            case V1_17_1:
+            case V1_18_1:
+            case V1_18_2:
+            case V1_19_4:
+            case V1_20_4:
+                // Older versions
+                result = Registry.EFFECT.get(NamespacedKey.minecraft("slow_digging"));
                 break;
             default:
-                result = Registry.EFFECT.get(NamespacedKey.minecraft("SLOW_DIGGING"));
+                // Latest versions
+                result = Registry.EFFECT.get(NamespacedKey.minecraft("mining_fatigue"));
                 break;
         }
         if (result == null) {
@@ -135,12 +234,18 @@ public class CompatibilityUtil {
     public static Enchantment getProtectionEnchantment() {
         Enchantment result;
         switch(getApiVersion()) {
-            case V1_20_6:
-            case V1_21_0:
-                result = Registry.ENCHANTMENT.get(NamespacedKey.minecraft("PROTECTION"));
+            case V1_16_5:
+            case V1_17_1:
+            case V1_18_1:
+            case V1_18_2:
+            case V1_19_4:
+            case V1_20_4:
+                // Older versions
+                result = Registry.ENCHANTMENT.get(NamespacedKey.minecraft("protection_environmental"));
                 break;
             default:
-                result = Registry.ENCHANTMENT.get(NamespacedKey.minecraft("PROTECTION_ENVIRONMENTAL"));
+                // Latest versions
+                result = Registry.ENCHANTMENT.get(NamespacedKey.minecraft("protection"));
                 break;
         }
         if (result == null) {
@@ -149,6 +254,55 @@ public class CompatibilityUtil {
             for (Enchantment enchant : Registry.ENCHANTMENT) {
                 ChatUtil.printConsole(enchant.getKey().toString());
             }
+        }
+        return result;
+    }
+
+    /**
+     * Gets the Enchantment field that matches the given name.
+     * When the Bukkit version is 1.20.6 or later, this method attempts to map current namespace to older ones.
+     * When the Bukkit version is before 1.20.6, this method attempts to map names to the appropriate version namespace.
+     * @param name The name of the enchantment, either old or new names
+     * @return The Enchantment appropriate for the current version
+     */
+    public static Enchantment getEnchantment(String name) {
+        EnchantComp enchant = EnchantComp.getFromName(name);
+        if (enchant == null) {
+            // Could not match name to a known enchantment
+            ChatUtil.printConsoleError("Failed to find enchantment from name, \""+name+"\", make sure the name matches a known enchantment from the Spigot API.");
+            return null;
+        }
+        String enchantNamespace;
+        switch (getApiVersion()) {
+            case V1_16_5:
+            case V1_17_1:
+            case V1_18_1:
+            case V1_18_2:
+            case V1_19_4:
+            case V1_20_4:
+                // Older versions
+                enchantNamespace = enchant.namespace1;
+                if (enchantNamespace.isEmpty()) {
+                    ChatUtil.printConsoleError("Failed to match enchantment \""+name+"\" to versions 1.20.4 or earlier. Enchantment does not exist.");
+                    return null;
+                }
+                break;
+            default:
+                // Latest versions
+                enchantNamespace = enchant.namespace2;
+                if (enchantNamespace.isEmpty()) {
+                    ChatUtil.printConsoleError("Failed to match enchantment \""+name+"\" to versions 1.20.6 or later. Enchantment does not exist.");
+                    return null;
+                }
+                break;
+        }
+        // Get the enchantment from the namespace registry
+        Enchantment result;
+        try {
+            result = Registry.ENCHANTMENT.get(NamespacedKey.minecraft(enchantNamespace));
+        } catch (IllegalArgumentException exception) {
+            ChatUtil.printConsoleError("Failed to get Enchantment using minecraft namespace \""+enchantNamespace+"\" for Bukkit version "+Bukkit.getVersion());
+            return null;
         }
         return result;
     }
@@ -165,19 +319,25 @@ public class CompatibilityUtil {
     public static Particle getParticle(String type) {
         try {
             switch (getApiVersion()) {
-                case V1_20_6:
-                case V1_21_0:
-                    if (type.equals("dust")) {
-                        return Particle.valueOf("DUST");
-                    } else if (type.equals("spell")) {
-                        return Particle.valueOf("EFFECT");
-                    }
-                    break;
-                default:
+                case V1_16_5:
+                case V1_17_1:
+                case V1_18_1:
+                case V1_18_2:
+                case V1_19_4:
+                case V1_20_4:
+                    // Older versions
                     if (type.equals("dust")) {
                         return Particle.valueOf("REDSTONE");
                     } else if (type.equals("spell")) {
                         return Particle.valueOf("SPELL_MOB_AMBIENT");
+                    }
+                    break;
+                default:
+                    // Latest versions
+                    if (type.equals("dust")) {
+                        return Particle.valueOf("DUST");
+                    } else if (type.equals("spell")) {
+                        return Particle.valueOf("EFFECT");
                     }
                     break;
             }
@@ -198,19 +358,25 @@ public class CompatibilityUtil {
     public static EntityType getEntityType(String type) {
         try {
             switch (getApiVersion()) {
-                case V1_20_6:
-                case V1_21_0:
-                    if (type.equals("item")) {
-                        return EntityType.valueOf("ITEM");
-                    } else if (type.equals("potion")) {
-                        return EntityType.valueOf("POTION");
-                    }
-                    break;
-                default:
+                case V1_16_5:
+                case V1_17_1:
+                case V1_18_1:
+                case V1_18_2:
+                case V1_19_4:
+                case V1_20_4:
+                    // Older versions
                     if (type.equals("item")) {
                         return EntityType.valueOf("DROPPED_ITEM");
                     } else if (type.equals("potion")) {
                         return EntityType.valueOf("SPLASH_POTION");
+                    }
+                    break;
+                default:
+                    // Latest versions
+                    if (type.equals("item")) {
+                        return EntityType.valueOf("ITEM");
+                    } else if (type.equals("potion")) {
+                        return EntityType.valueOf("POTION");
                     }
                     break;
             }
@@ -226,17 +392,23 @@ public class CompatibilityUtil {
     @SuppressWarnings({"removal","deprecation"})
     public static PotionMeta setPotionData(PotionMeta meta, PotionType type, boolean isExtended, boolean isUpgraded) {
         switch(getApiVersion()) {
-            case V1_20_6:
-            case V1_21_0:
-                meta.setBasePotionType(lookupPotionType(type,isExtended,isUpgraded));
-                break;
-            default:
+            case V1_16_5:
+            case V1_17_1:
+            case V1_18_1:
+            case V1_18_2:
+            case V1_19_4:
+            case V1_20_4:
+                // Older versions
                 try {
                     meta.setBasePotionData(new org.bukkit.potion.PotionData(type, isExtended, isUpgraded));
                 } catch(IllegalArgumentException e) {
                     meta.setBasePotionData(new org.bukkit.potion.PotionData(type, false, false));
                     ChatUtil.printConsoleError("Invalid options extended="+isExtended+", upgraded="+isUpgraded+" for potion "+type.name()+" in loot.yml");
                 }
+                break;
+            default:
+                // Latest versions
+                meta.setBasePotionType(lookupPotionType(type,isExtended,isUpgraded));
                 break;
         }
         return meta;

--- a/core/src/main/java/com/github/rumsfield/konquest/utility/CompatibilityUtil.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/utility/CompatibilityUtil.java
@@ -16,6 +16,7 @@ import org.bukkit.inventory.ItemFlag;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 
+import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.List;
@@ -29,80 +30,85 @@ public class CompatibilityUtil {
      * Map old enchantment namespaces to new ones
      */
     public enum EnchantComp {
-        // Enchantment              Pre 1.20.6                      1.20.6 and later
-        // Common
-        BINDING_CURSE               ("binding_curse",               "binding_curse"),
-        CHANNELING                  ("channeling",                  "channeling"),
-        DEPTH_STRIDER               ("depth_strider",               "depth_strider"),
-        FIRE_ASPECT                 ("fire_aspect",                 "fire_aspect"),
-        FROST_WALKER                ("frost_walker",                "frost_walker"),
-        IMPALING                    ("impaling",                    "impaling"),
-        KNOCKBACK                   ("knockback",                   "knockback"),
-        LOYALTY                     ("loyalty",                     "loyalty"),
-        LURE                        ("lure",                        "lure"),
-        MENDING                     ("mending",                     "mending"),
-        MULTISHOT                   ("multishot",                   "multishot"),
-        PIERCING                    ("piercing",                    "piercing"),
-        QUICK_CHARGE                ("quick_charge",                "quick_charge"),
-        RIPTIDE                     ("riptide",                     "riptide"),
-        SILK_TOUCH                  ("silk_touch",                  "silk_touch"),
-        SOUL_SPEED                  ("soul_speed",                  "soul_speed"),
-        SWEEPING_EDGE               ("sweeping_edge",               "sweeping_edge"),
-        SWIFT_SNEAK                 ("swift_sneak",                 "swift_sneak"),
-        THORNS                      ("thorns",                      "thorns"),
-        VANISHING_CURSE             ("vanishing_curse",             "vanishing_curse"),
+        // Enchantment Field Name   1.16.5 - 1.18.2             1.19.4 - 1.20.4             1.20.6 +
+
+        // Common names to all versions
+        BINDING_CURSE               ("binding_curse",           "binding_curse",            "binding_curse"),
+        CHANNELING                  ("channeling",              "channeling",               "channeling"),
+        DEPTH_STRIDER               ("depth_strider",           "depth_strider",            "depth_strider"),
+        FIRE_ASPECT                 ("fire_aspect",             "fire_aspect",              "fire_aspect"),
+        FROST_WALKER                ("frost_walker",            "frost_walker",             "frost_walker"),
+        IMPALING                    ("impaling",                "impaling",                 "impaling"),
+        KNOCKBACK                   ("knockback",               "knockback",                "knockback"),
+        LOYALTY                     ("loyalty",                 "loyalty",                  "loyalty"),
+        LURE                        ("lure",                    "lure",                     "lure"),
+        MENDING                     ("mending",                 "mending",                  "mending"),
+        MULTISHOT                   ("multishot",               "multishot",                "multishot"),
+        PIERCING                    ("piercing",                "piercing",                 "piercing"),
+        QUICK_CHARGE                ("quick_charge",            "quick_charge",             "quick_charge"),
+        RIPTIDE                     ("riptide",                 "riptide",                  "riptide"),
+        SILK_TOUCH                  ("silk_touch",              "silk_touch",               "silk_touch"),
+        SOUL_SPEED                  ("soul_speed",              "soul_speed",               "soul_speed"),
+        SWEEPING_EDGE               ("sweeping",                "sweeping",                 "sweeping_edge"),
+        THORNS                      ("thorns",                  "thorns",                   "thorns"),
+        VANISHING_CURSE             ("vanishing_curse",         "vanishing_curse",          "vanishing_curse"),
+
+        // 1.19.4 and later names
+        SWIFT_SNEAK                 ("",                        "swift_sneak",              "swift_sneak"),
 
         // 1.20.4 and earlier
-        WATER_WORKING               ("water_working",               "aqua_afinity"),
-        DAMAGE_ARTHROPODS           ("damage_arthropods",           "bane_of_arthropods"),
-        PROTECTION_EXPLOSIONS       ("protection_explosions",       "blast_protection"),
-        DIG_SPEED                   ("dig_speed",                   "efficiency"),
-        PROTECTION_FALL             ("protection_fall",             "feather_falling"),
-        PROTECTION_FIRE             ("protection_fire",             "fire_protection"),
-        ARROW_FIRE                  ("arrow_fire",                  "flame"),
-        LOOT_BONUS_BLOCKS           ("loot_bonus_blocks",           "fortune"),
-        ARROW_INFINITE              ("arrow_infinite",              "infinity"),
-        LOOT_BONUS_MOBS             ("loot_bonus_mobs",             "looting"),
-        LUCK                        ("luck",                        "luck_of_the_sea"),
-        ARROW_DAMAGE                ("arrow_damage",                "power"),
-        PROTECTION_PROJECTILE       ("protection_projectile",       "projectile_protection"),
-        PROTECTION_ENVIRONMENTAL    ("protection_environmental",    "protection"),
-        ARROW_KNOCKBACK             ("arrow_knockback",             "punch"),
-        OXYGEN                      ("oxygen",                      "respiration"),
-        DAMAGE_ALL                  ("damage_all",                  "sharpness"),
-        DAMAGE_UNDEAD               ("damage_undead",               "smite"),
-        DURABILITY                  ("durability",                  "unbreaking"),
+        WATER_WORKER                ("aqua_affinity",           "aqua_affinity",            "aqua_affinity"),
+        DAMAGE_ARTHROPODS           ("bane_of_arthropods",      "bane_of_arthropods",       "bane_of_arthropods"),
+        PROTECTION_EXPLOSIONS       ("blast_protection",        "blast_protection",         "blast_protection"),
+        DIG_SPEED                   ("efficiency",              "efficiency",               "efficiency"),
+        PROTECTION_FALL             ("feather_falling",         "feather_falling",          "feather_falling"),
+        PROTECTION_FIRE             ("fire_protection",         "fire_protection",          "fire_protection"),
+        ARROW_FIRE                  ("flame",                   "flame",                    "flame"),
+        LOOT_BONUS_BLOCKS           ("fortune",                 "fortune",                  "fortune"),
+        ARROW_INFINITE              ("infinity",                "infinity",                 "infinity"),
+        LOOT_BONUS_MOBS             ("looting",                 "looting",                  "looting"),
+        LUCK                        ("luck_of_the_sea",         "luck_of_the_sea",          "luck_of_the_sea"),
+        ARROW_DAMAGE                ("power",                   "power",                    "power"),
+        PROTECTION_PROJECTILE       ("projectile_protection",   "projectile_protection",    "projectile_protection"),
+        PROTECTION_ENVIRONMENTAL    ("protection",              "protection",               "protection"),
+        ARROW_KNOCKBACK             ("punch",                   "punch",                    "punch"),
+        OXYGEN                      ("respiration",             "respiration",              "respiration"),
+        DAMAGE_ALL                  ("sharpness",               "sharpness",                "sharpness"),
+        DAMAGE_UNDEAD               ("smite",                   "smite",                    "smite"),
+        DURABILITY                  ("unbreaking",              "unbreaking",               "unbreaking"),
 
         // 1.20.6 and later
-        AQUA_AFINITY                ("water_working",               "aqua_afinity"),
-        BANE_OF_ARTHROPODS          ("damage_arthropods",           "bane_of_arthropods"),
-        BLAST_PROTECTION            ("protection_explosions",       "blast_protection"),
-        BREACH                      ("",                            "breach"),
-        DENSITY                     ("",                            "density"),
-        EFFICIENCY                  ("dig_speed",                   "efficiency"),
-        FEATHER_FALLING             ("protection_fall",             "feather_falling"),
-        FIRE_PROTECTION             ("protection_fire",             "fire_protection"),
-        FLAME                       ("arrow_fire",                  "flame"),
-        FORTUNE                     ("loot_bonus_blocks",           "fortune"),
-        INFINITY                    ("arrow_infinite",              "infinity"),
-        LOOTING                     ("loot_bonus_mobs",             "looting"),
-        LUCK_OF_THE_SEA             ("luck",                        "luck_of_the_sea"),
-        POWER                       ("arrow_damage",                "power"),
-        PROJECTILE_PROTECTION       ("protection_projectile",       "projectile_protection"),
-        PROTECTION                  ("protection_environmental",    "protection"),
-        PUNCH                       ("arrow_knockback",             "punch"),
-        RESPIRATION                 ("oxygen",                      "respiration"),
-        SHARPNESS                   ("damage_all",                  "sharpness"),
-        SMITE                       ("damage_undead",               "smite"),
-        UNBREAKING                  ("durability",                  "unbreaking"),
-        WIND_BURST                  ("",                            "wind_burst");
+        AQUA_AFFINITY               ("aqua_affinity",           "aqua_affinity",            "aqua_affinity"),
+        BANE_OF_ARTHROPODS          ("bane_of_arthropods",      "bane_of_arthropods",       "bane_of_arthropods"),
+        BLAST_PROTECTION            ("blast_protection",        "blast_protection",         "blast_protection"),
+        EFFICIENCY                  ("efficiency",              "efficiency",               "efficiency"),
+        FEATHER_FALLING             ("feather_falling",         "feather_falling",          "feather_falling"),
+        FIRE_PROTECTION             ("fire_protection",         "fire_protection",          "fire_protection"),
+        FLAME                       ("flame",                   "flame",                    "flame"),
+        FORTUNE                     ("fortune",                 "fortune",                  "fortune"),
+        INFINITY                    ("infinity",                "infinity",                 "infinity"),
+        LOOTING                     ("looting",                 "looting",                  "looting"),
+        LUCK_OF_THE_SEA             ("luck_of_the_sea",         "luck_of_the_sea",          "luck_of_the_sea"),
+        POWER                       ("power",                   "power",                    "power"),
+        PROJECTILE_PROTECTION       ("projectile_protection",   "projectile_protection",    "projectile_protection"),
+        PROTECTION                  ("protection",              "protection",               "protection"),
+        PUNCH                       ("punch",                   "punch",                    "punch"),
+        RESPIRATION                 ("respiration",             "respiration",              "respiration"),
+        SHARPNESS                   ("sharpness",               "sharpness",                "sharpness"),
+        SMITE                       ("smite",                   "smite",                    "smite"),
+        UNBREAKING                  ("unbreaking",              "unbreaking",               "unbreaking"),
+        BREACH                      ("",                        "",                         "breach"),
+        DENSITY                     ("",                        "",                         "density"),
+        WIND_BURST                  ("",                        "",                         "wind_burst");
 
-        public final String namespace1; // Pre 1.20.6
-        public final String namespace2; // 1.20.6 and later
+        public final String namespace1;
+        public final String namespace2;
+        public final String namespace3;
 
-        EnchantComp(String namespace1, String namespace2) {
-            this.namespace1 = namespace1;
-            this.namespace2 = namespace2;
+        EnchantComp(String namespace1, String namespace2, String namespace3) {
+            this.namespace1 = namespace1; // 1.16.5 - 1.18.2
+            this.namespace2 = namespace2; // 1.19.4 - 1.20.4
+            this.namespace3 = namespace3; // 1.20.6 +
         }
 
         public static EnchantComp getFromName(String name) {
@@ -115,6 +121,25 @@ public class CompatibilityUtil {
         }
     }
 
+    @SuppressWarnings("deprecation")
+    public static boolean validateEnchantments() {
+        // Loop over all API Enchantment fields
+        boolean pass = true;
+        for (Enchantment enchant : Enchantment.values()) {
+            String apiName = enchant.getName();
+            Enchantment enchantComp = getEnchantment(apiName);
+            if (enchantComp == null) {
+                pass = false;
+            }
+        }
+        if (pass) {
+            ChatUtil.printConsoleAlert("Successfully validated API Enchantments");
+        } else {
+            ChatUtil.printConsoleError("Failed to validate some API Enchantments, report this as a bug to the plugin author!");
+        }
+        return pass;
+    }
+
     public enum SpigotApiVersion {
         INVALID,
         V1_16_5,
@@ -124,7 +149,7 @@ public class CompatibilityUtil {
         V1_19_4,
         V1_20_4,
         V1_20_6,
-        V1_21_0
+        V1_21
     }
 
     public static SpigotApiVersion apiVersion = getApiVersion();
@@ -145,8 +170,8 @@ public class CompatibilityUtil {
             return SpigotApiVersion.V1_20_4;
         } else if (bukkitVersion.contains("1.20.6")) {
             return SpigotApiVersion.V1_20_6;
-        } else if (bukkitVersion.contains("1.20.0")) {
-            return SpigotApiVersion.V1_21_0;
+        } else if (bukkitVersion.contains("1.21")) {
+            return SpigotApiVersion.V1_21;
         } else {
             ChatUtil.printConsoleError("Failed to resolve valid API version for compatibility: "+bukkitVersion);
             ChatUtil.showStackTrace();
@@ -218,6 +243,7 @@ public class CompatibilityUtil {
 
     /* Class Field Name Requests */
 
+    @SuppressWarnings("deprecation")
     public static PotionEffectType getMiningFatigue() {
         PotionEffectType result;
         switch(apiVersion) {
@@ -226,56 +252,33 @@ public class CompatibilityUtil {
             case V1_18_1:
             case V1_18_2:
             case V1_19_4:
-            case V1_20_4:
-                // Older versions
-                result = Registry.EFFECT.get(NamespacedKey.minecraft("slow_digging"));
+                // These version use a direct name lookup
+                result = PotionEffectType.getByName("SLOW_DIGGING");
+                if (result == null) {
+                    ChatUtil.printConsoleError("Failed to get Mining Fatigue PotionEffectType using getByName for Bukkit version "+Bukkit.getVersion());
+                    ChatUtil.printConsole("Valid Names for Potion Effects are:");
+                    for (PotionEffectType effect : PotionEffectType.values()) {
+                        ChatUtil.printConsole(effect.getName());
+                    }
+                }
                 break;
             default:
-                // Latest versions
+                // Latest versions uses namespace with Registry
                 result = Registry.EFFECT.get(NamespacedKey.minecraft("mining_fatigue"));
+                if (result == null) {
+                    ChatUtil.printConsoleError("Failed to get Mining Fatigue PotionEffectType using Registry for Bukkit version "+Bukkit.getVersion());
+                    ChatUtil.printConsole("Valid NamespacedKeys for Potion Effects are:");
+                    for (PotionEffectType effect : Registry.EFFECT) {
+                        ChatUtil.printConsole(effect.getKey().toString());
+                    }
+                }
                 break;
-        }
-        if (result == null) {
-            ChatUtil.printConsoleError("Failed to get Mining Fatigue PotionEffectType for Bukkit version "+Bukkit.getVersion());
-            ChatUtil.printConsole("Valid NamespacedKeys for Potion Effects are:");
-            for (PotionEffectType effect : Registry.EFFECT) {
-                ChatUtil.printConsole(effect.getKey().toString());
-            }
-        }
-        return result;
-    }
-
-    public static Enchantment getProtectionEnchantment() {
-        Enchantment result;
-        switch(apiVersion) {
-            case V1_16_5:
-            case V1_17_1:
-            case V1_18_1:
-            case V1_18_2:
-            case V1_19_4:
-            case V1_20_4:
-                // Older versions
-                result = Registry.ENCHANTMENT.get(NamespacedKey.minecraft("protection_environmental"));
-                break;
-            default:
-                // Latest versions
-                result = Registry.ENCHANTMENT.get(NamespacedKey.minecraft("protection"));
-                break;
-        }
-        if (result == null) {
-            ChatUtil.printConsoleError("Failed to get Protection Enchantment for Bukkit version "+Bukkit.getVersion());
-            ChatUtil.printConsole("Valid NamespacedKeys for Enchantments are:");
-            for (Enchantment enchant : Registry.ENCHANTMENT) {
-                ChatUtil.printConsole(enchant.getKey().toString());
-            }
         }
         return result;
     }
 
     /**
      * Gets the Enchantment field that matches the given name.
-     * When the Bukkit version is 1.20.6 or later, this method attempts to map current namespace to older ones.
-     * When the Bukkit version is before 1.20.6, this method attempts to map names to the appropriate version namespace.
      * @param name The name of the enchantment, either old or new names
      * @return The Enchantment appropriate for the current version
      */
@@ -292,18 +295,25 @@ public class CompatibilityUtil {
             case V1_17_1:
             case V1_18_1:
             case V1_18_2:
-            case V1_19_4:
-            case V1_20_4:
-                // Older versions
+                // Version 1.16.5 - 1.18.2
                 enchantNamespace = enchant.namespace1;
                 if (enchantNamespace.isEmpty()) {
-                    ChatUtil.printConsoleError("Failed to match enchantment \""+name+"\" to versions 1.20.4 or earlier. Enchantment does not exist.");
+                    ChatUtil.printConsoleError("Failed to match enchantment \""+name+"\" to versions 1.16.5 - 1.18.2. Enchantment does not exist.");
+                    return null;
+                }
+                break;
+            case V1_19_4:
+            case V1_20_4:
+                // Versions 1.19.4 - 1.20.4
+                enchantNamespace = enchant.namespace2;
+                if (enchantNamespace.isEmpty()) {
+                    ChatUtil.printConsoleError("Failed to match enchantment \""+name+"\" to versions 1.19.4 - 1.20.4. Enchantment does not exist.");
                     return null;
                 }
                 break;
             default:
                 // Latest versions
-                enchantNamespace = enchant.namespace2;
+                enchantNamespace = enchant.namespace3;
                 if (enchantNamespace.isEmpty()) {
                     ChatUtil.printConsoleError("Failed to match enchantment \""+name+"\" to versions 1.20.6 or later. Enchantment does not exist.");
                     return null;
@@ -315,8 +325,14 @@ public class CompatibilityUtil {
         try {
             result = Registry.ENCHANTMENT.get(NamespacedKey.minecraft(enchantNamespace));
         } catch (IllegalArgumentException exception) {
+            result = null;
+        }
+        if (result == null) {
             ChatUtil.printConsoleError("Failed to get Enchantment using minecraft namespace \""+enchantNamespace+"\" for Bukkit version "+Bukkit.getVersion());
-            return null;
+            ChatUtil.printConsole("Valid NamespacedKeys for Enchantments are:");
+            for (Enchantment enchantment : Registry.ENCHANTMENT) {
+                ChatUtil.printConsole(enchantment.getKey().toString());
+            }
         }
         return result;
     }
@@ -473,7 +489,10 @@ public class CompatibilityUtil {
             meta.addItemFlags(flag);
         }
         if (hasProtection) {
-            meta.addEnchant(CompatibilityUtil.getProtectionEnchantment(), 1, true);
+            Enchantment protectionEnchant = CompatibilityUtil.getEnchantment("protection_environmental");
+            if (protectionEnchant != null) {
+                meta.addEnchant(protectionEnchant, 1, true);
+            }
         }
         meta.setDisplayName(name);
         meta.setLore(loreList);

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
# Konquest Pull Request

Closes #229

## Summary
This branch updates the Spigot API dependency to version 1.21. With that, many optimizations to existing code were made to enable backwards-compatibility to 1.16.5.

## Change Details
* Project now requires JDK 21.
* Project now uses Gradle 8.8.
* Changed both `api` and `core` modules to use Spigot 1.21 API.
* Updated dependency repositories and versions for Dynmap and QuickShop.
* Added plugin support for Spigot 1.20.6 and 1.21.
* Optimized code for backwards-compatibility
  * Changed all icon classes to use a common static method to make ItemStacks, which now adds a dummy generic attribute modifier in order to correctly hide all item flags.
  * Added utility methods to get enums in appropriate API version, for potions, particles and enchantments.
  * Added reflection method to get top inventory from an InventoryView used by InventoryEvent handlers.
* Updated diplomacy logic to avoid setting relations with the same kingdom.
* Removed debug stack trace printing in console for blocked player protections.

## Checklist
- [x] I have merged the latest `develop` commit into this branch and resolved any conflicts.
- [x] I have tested this branch and it is working as intended.
- [x] This Pull Request is ready for review and merging.