### PR TITLE
Updated compatibility version checking #246

### DIFF
--- a/core/src/main/java/com/github/rumsfield/konquest/Konquest.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/Konquest.java
@@ -226,35 +226,30 @@ public class Konquest implements KonquestAPI, Timeable {
     	boolean isProtocolLibEnabled = integrationManager.getProtocolLib().isEnabled();
     	// Version-specific cases
     	try {
-	    	switch(CompatibilityUtil.apiVersion) {
-	    		case V1_16_5:
-					isVersionSupported = true;
-					if(isProtocolLibEnabled) { versionHandler = new Handler_1_16_R3(); }
-	    			break;
-	    		case V1_17_1:
-					isVersionSupported = true;
-					if(isProtocolLibEnabled) { versionHandler = new Handler_1_17_R1(); }
-	    			break;
-	    		case V1_18_1:
-					isVersionSupported = true;
-					if(isProtocolLibEnabled) { versionHandler = new Handler_1_18_R1(); }
-	    			break;
-	    		case V1_18_2:
-					isVersionSupported = true;
-					if(isProtocolLibEnabled) { versionHandler = new Handler_1_18_R2(); }
-	    			break;
-	    		case V1_19_4:
-				case V1_20_4:
-				case V1_20_6:
-				case V1_21:
-					isVersionSupported = true;
-					if(isProtocolLibEnabled) { versionHandler = new Handler_1_19_R1(); }
-	    			break;
-	    		default:
-					isVersionSupported = false;
-	    			ChatUtil.printConsoleError("This version of Minecraft is not supported by Konquest!");
-	    			break;
-	    	}
+			if (CompatibilityUtil.apiVersion.compareTo(new Version("1.16.5")) <= 0) {
+				isVersionSupported = true;
+				if(isProtocolLibEnabled) { versionHandler = new Handler_1_16_R3(); }
+
+			} else if (CompatibilityUtil.apiVersion.compareTo(new Version("1.17.1")) <= 0) {
+				isVersionSupported = true;
+				if(isProtocolLibEnabled) { versionHandler = new Handler_1_17_R1(); }
+
+			} else if (CompatibilityUtil.apiVersion.compareTo(new Version("1.18.1")) <= 0) {
+				isVersionSupported = true;
+				if(isProtocolLibEnabled) { versionHandler = new Handler_1_18_R1(); }
+
+			} else if (CompatibilityUtil.apiVersion.compareTo(new Version("1.18.2")) <= 0) {
+				isVersionSupported = true;
+				if(isProtocolLibEnabled) { versionHandler = new Handler_1_18_R2(); }
+
+			} else if (CompatibilityUtil.apiVersion.compareTo(new Version("1.21")) <= 0) {
+				isVersionSupported = true;
+				if(isProtocolLibEnabled) { versionHandler = new Handler_1_19_R1(); }
+
+			} else {
+				isVersionSupported = false;
+				ChatUtil.printConsoleError("This version of Minecraft is not supported by Konquest!");
+			}
     	} catch (Exception | NoClassDefFoundError e) {
     		ChatUtil.printConsoleError("Failed to setup a version handler, ProtocolLib is probably missing. ");
     		e.printStackTrace();

--- a/core/src/main/java/com/github/rumsfield/konquest/KonquestPlugin.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/KonquestPlugin.java
@@ -37,7 +37,7 @@ public class KonquestPlugin extends JavaPlugin {
 	boolean isSetupEconomy = false;
 	boolean isSetupMetrics = false;
 	boolean isSetupPlaceholders = false;
-	boolean isEnchantmentsValidated = false;
+	boolean isCompatibiltyValidated = false;
 
 	@Override
 	public void onLoad() {
@@ -66,6 +66,12 @@ public class KonquestPlugin extends JavaPlugin {
  			pluginManager.disablePlugin(this);
             return;
         }
+	    // Check Version
+		if (CompatibilityUtil.apiVersion == null) {
+			getLogger().severe(String.format("%s disabled due to invalid Bukkit API version.", getDescription().getName()));
+			pluginManager.disablePlugin(this);
+			return;
+		}
  		// Enable metrics
  		isSetupMetrics = loadMetrics();
  		// Register command executors & listeners
@@ -76,8 +82,8 @@ public class KonquestPlugin extends JavaPlugin {
         registerApi(konquest);
         // Register placeholders
 		isSetupPlaceholders = registerPlaceholders();
-		// Validate API Enchantments
-		isEnchantmentsValidated = CompatibilityUtil.validateEnchantments();
+		// Validate API Compatibility
+		isCompatibiltyValidated = CompatibilityUtil.runBIT();
         // Check for updates
         checkForUpdates();
         // Done!
@@ -207,7 +213,7 @@ public class KonquestPlugin extends JavaPlugin {
 				String.format(lineTemplate,"Placeholders Registered",boolean2status(isSetupPlaceholders)),
 				String.format(lineTemplate,"Team Colors Registered",boolean2status(konquest.isVersionHandlerEnabled())),
 				String.format(lineTemplate,"Minecraft Version Supported",boolean2status(konquest.isVersionSupported())),
-				String.format(lineTemplate,"API Enchantments Validated",boolean2status(isEnchantmentsValidated))
+				String.format(lineTemplate,"API Compatibility Validated",boolean2status(isCompatibiltyValidated))
 		};
 		ChatUtil.printConsoleAlert("Final Status...");
 		for (String row : status) {

--- a/core/src/main/java/com/github/rumsfield/konquest/utility/Version.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/utility/Version.java
@@ -24,6 +24,12 @@ public class Version implements Comparable<Version> {
         this.version = version;
     }
 
+    /**
+     * Compares versions
+     * @param that the object to be compared.
+     * @return 0 when versions are equal, -1 when this version is less than that version,
+     *         and 1 when this version is greater than that version.
+     */
     @Override public int compareTo(@NotNull Version that) {
         String[] thisParts = this.get().split("\\.");
         String[] thatParts = that.get().split("\\.");


### PR DESCRIPTION
# Konquest Pull Request

Closes #246

## Summary
Changes the bukkit version handling to use more flexible Version class rather than accounting for each version with an Enum. Also updates compatibility methods to be more flexible when handling older versions.

## Checklist
- [x] I have merged the latest `develop` commit into this branch and resolved any conflicts.
- [x] I have tested this branch and it is working as intended.
- [x] This Pull Request is ready for review and merging.