### PR TITLE
Bugfix/273 town protection alerts

### DIFF
--- a/core/src/main/java/com/github/rumsfield/konquest/model/KonTown.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/model/KonTown.java
@@ -994,6 +994,7 @@ public class KonTown extends KonTerritory implements KonquestTown, KonBarDisplay
 				ChatUtil.printDebug("Town Watch protection enabled without warmup in "+getName());
 				isTownWatchProtected = true;
 				protectedWarmupTimer.stopTimer();
+				return true;
 			} else if (protectedWarmupTimer.getTime() == -1) {
 				// Timer is not running, and config time is non-zero
 				// start warmup timer
@@ -1001,8 +1002,8 @@ public class KonTown extends KonTerritory implements KonquestTown, KonBarDisplay
 				protectedWarmupTimer.stopTimer();
 				protectedWarmupTimer.setTime(offlineProtectedWarmupSeconds);
 				protectedWarmupTimer.startTimer();
+				return true;
 			}
-			return true;
 		}
 		// Default
 		return false;

--- a/core/src/main/java/com/github/rumsfield/konquest/utility/CompatibilityUtil.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/utility/CompatibilityUtil.java
@@ -472,7 +472,7 @@ public class CompatibilityUtil {
         return buildItem(mat, name, loreList, hasProtection, null);
     }
 
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings({"deprecation","removal"})
     public static ItemStack buildItem(Material mat, String name, List<String> loreList, boolean hasProtection, OfflinePlayer playerHead) {
         ItemStack item;
         if (playerHead == null && mat != null) {
@@ -511,7 +511,7 @@ public class CompatibilityUtil {
      * @param modName The name of the modifier for version 1.20.6 and older
      * @param modKey The key of the modifier for version 1.21 and newer
      */
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings({"deprecation","removal"})
     public static void applyHealthModifier(Player player, double modAmount, String modName, NamespacedKey modKey) {
         // Check for existing modifier
         boolean isModActive = false;


### PR DESCRIPTION
# Konquest Pull Request

Closes #273

## Summary
Fixes town protection logic to only broadcast warmup message when a town starts its warmup timer, not every time a player leaves the server.

## Checklist
- [x] I have merged the latest `develop` commit into this branch and resolved any conflicts.
- [x] I have tested this branch and it is working as intended.
- [x] This Pull Request is ready for review and merging.