### PR TITLE
Feature/272 ruin placeholders

### DIFF
--- a/core/src/main/java/com/github/rumsfield/konquest/KonquestPlaceholderExpansion.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/KonquestPlaceholderExpansion.java
@@ -331,7 +331,7 @@ public class KonquestPlaceholderExpansion extends PlaceholderExpansion implement
 				result = placeholderManager.getPlayerKingdomScore(player);
 				break;
 	        default: 
-	        	// Check for kingdom-specific placeholders
+	        	// Check for kingdom-specific and ruin-specific placeholders
 
 	        	/* %konquest_players_<kingdom>% */
 				if(identifierLower.matches("^players_.+$")) {
@@ -374,8 +374,36 @@ public class KonquestPlaceholderExpansion extends PlaceholderExpansion implement
 	        			String kingdomName = identifierLower.substring(6);
 	        			result = placeholderManager.getKingdomScore(kingdomName);
 	        		} catch(IndexOutOfBoundsException ignored) {}
-	        		
-	        	}
+
+				/* %konquest_ruin_cooldown_<ruin>% */
+				} else if(identifierLower.matches("^ruin_cooldown_.+$")) {
+					try {
+						String ruinName = identifierLower.substring(14);
+						result = placeholderManager.getRuinCooldown(ruinName);
+					} catch(IndexOutOfBoundsException ignored) {}
+
+				/* %konquest_ruin_capture_<ruin>% */
+				} else if(identifierLower.matches("^ruin_capture_.+$")) {
+					try {
+						String ruinName = identifierLower.substring(13);
+						result = placeholderManager.getRuinCapture(ruinName);
+					} catch(IndexOutOfBoundsException ignored) {}
+
+				/* %konquest_ruin_criticals_<ruin>% */
+				} else if(identifierLower.matches("^ruin_criticals_.+$")) {
+					try {
+						String ruinName = identifierLower.substring(15);
+						result = placeholderManager.getRuinCriticals(ruinName);
+					} catch(IndexOutOfBoundsException ignored) {}
+
+				/* %konquest_ruin_spawns_<ruin>% */
+				} else if(identifierLower.matches("^ruin_spawns_.+$")) {
+					try {
+						String ruinName = identifierLower.substring(12);
+						result = placeholderManager.getRuinSpawns(ruinName);
+					} catch(IndexOutOfBoundsException ignored) {}
+
+				}
 	        	break;
         }
 

--- a/core/src/main/java/com/github/rumsfield/konquest/manager/PlaceholderManager.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/manager/PlaceholderManager.java
@@ -443,10 +443,18 @@ public class PlaceholderManager implements KonquestPlaceholderManager {
 		Long futureTime = now.getTime() + (cooldownSeconds* 1000L);
 		boolean isReady = false;
 		if (kingdomCooldownTimes.containsKey(nameKey)) {
-			// A cache entry exists
-			if (now.after(new Date(kingdomCooldownTimes.get(nameKey).get(valueType)))) {
-				// The cool-down time is over
+			// A kingdom cache entry exists
+			if (kingdomCooldownTimes.get(nameKey).containsKey(valueType)) {
+				// A type cache entry exists
+				if (now.after(new Date(kingdomCooldownTimes.get(nameKey).get(valueType)))) {
+					// The cool-down time is over
+					isReady = true;
+					kingdomCooldownTimes.get(nameKey).put(valueType, futureTime);
+				}
+			} else {
 				isReady = true;
+				// Create a new type cache entry
+				kingdomCache.get(nameKey).put(valueType, 0);
 				kingdomCooldownTimes.get(nameKey).put(valueType, futureTime);
 			}
 		} else if (kingdomManager.isKingdom(nameKey)) {

--- a/core/src/main/java/com/github/rumsfield/konquest/manager/PlaceholderManager.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/manager/PlaceholderManager.java
@@ -42,6 +42,7 @@ public class PlaceholderManager implements KonquestPlaceholderManager {
 	private final Konquest konquest;
 	private final PlayerManager playerManager;
 	private final KingdomManager kingdomManager;
+	private final RuinManager ruinManager;
 	private final TerritoryManager territoryManager;
 	private int cooldownSeconds;
 	private final Comparator<Ranked> rankedComparator;
@@ -58,6 +59,7 @@ public class PlaceholderManager implements KonquestPlaceholderManager {
 		this.konquest = konquest;
 		this.playerManager = konquest.getPlayerManager();
 		this.kingdomManager = konquest.getKingdomManager();
+		this.ruinManager = konquest.getRuinManager();
 		this.territoryManager = konquest.getTerritoryManager();
 		this.cooldownSeconds = 0;
 		this.topScoreCooldownTime = 0L;
@@ -553,6 +555,7 @@ public class PlaceholderManager implements KonquestPlaceholderManager {
 		    	for(KonTown town : kingdomManager.getKingdom(name).getTowns()) {
 		    		value += town.getChunkList().size();
 		    	}
+				ChatUtil.printDebug("Got placeholder kingdom land for "+name);
 				kingdomCache.get(type).put(name, value);
 				// Update new cool-down time
 				kingdomCooldownTimes.put(type, now.getTime() + (cooldownSeconds* 1000L));
@@ -622,6 +625,46 @@ public class PlaceholderManager implements KonquestPlaceholderManager {
 			}
 			// Get value
 			result = ""+kingdomCache.get(type).get(name);
+		}
+		return result;
+	}
+
+	/*
+	 * Placeholder Ruin Requesters
+	 */
+
+	public String getRuinCooldown(String name) {
+		String result = "";
+		if(ruinManager.isRuin(name)) {
+			result = ruinManager.getRuin(name).getCaptureTime();
+			ChatUtil.printDebug("Got placeholder ruin cooldown");
+		}
+		return result;
+	}
+
+	public String getRuinCapture(String name) {
+		String result = "";
+		if(ruinManager.isRuin(name)) {
+			result = boolean2Lang(!ruinManager.getRuin(name).isCaptureDisabled());
+			ChatUtil.printDebug("Got placeholder ruin capture");
+		}
+		return result;
+	}
+
+	public String getRuinCriticals(String name) {
+		String result = "";
+		if(ruinManager.isRuin(name)) {
+			result = ""+ruinManager.getRuin(name).getCriticalLocations().size();
+			ChatUtil.printDebug("Got placeholder ruin criticals");
+		}
+		return result;
+	}
+
+	public String getRuinSpawns(String name) {
+		String result = "";
+		if(ruinManager.isRuin(name)) {
+			result = ""+ruinManager.getRuin(name).getSpawnLocations().size();
+			ChatUtil.printDebug("Got placeholder ruin spawns");
 		}
 		return result;
 	}

--- a/core/src/main/java/com/github/rumsfield/konquest/model/KonRuin.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/model/KonRuin.java
@@ -247,6 +247,12 @@ public class KonRuin extends KonTerritory implements KonquestRuin, KonBarDisplay
 	public String getCaptureCooldownString() {
 		return String.format("%02d:%02d", captureTimer.getMinutes(), captureTimer.getSeconds());
 	}
+
+	public String getCaptureTime() {
+		String noColor = "";
+		int timerCount = Math.max(captureTimer.getTime(),0);
+		return HelperUtil.getTimeFormat(timerCount, noColor);
+	}
 	
 	public void addBarPlayer(KonPlayer player) {
 		ruinBarAll.addPlayer(player.getBukkitPlayer());


### PR DESCRIPTION
# Konquest Pull Request

Closes #272

## Summary
Adds placeholders for Ruin territories by name, for number of critical hits, golem spawns, whether it can be captured, and cooldown timer. Also updates kingdom named placeholders to update correctly.

## Checklist
- [x] I have merged the latest `develop` commit into this branch and resolved any conflicts.
- [x] I have tested this branch and it is working as intended.
- [x] This Pull Request is ready for review and merging.