### PR TITLE
Feature/262 quickshop support

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -50,7 +50,9 @@ dependencies{
     // Integrated third-party plugins
     compileOnly("com.comphenix.protocol:ProtocolLib:5.0.0")
     compileOnly("com.github.jikoo.OpenInv:openinvapi:4.3.1")
-    compileOnly("org.maxgamer:QuickShop:5.1.2.5-SNAPSHOT")
+    compileOnly("net.kyori:adventure-api:4.17.0")
+    compileOnly("com.ghostchu:quickshop-common:6.2.0.6")
+    compileOnly("com.ghostchu:quickshop-api:6.2.0.6")
     compileOnly("com.acrobot.chestshop:chestshop:3.12")
     compileOnly("us.dynmap:DynmapCoreAPI:3.6")
     compileOnly("us.dynmap:dynmap-api:3.6")
@@ -64,7 +66,7 @@ dependencies{
     compileOnly("net.essentialsx:EssentialsX:2.20.1")
 
     implementation("org.apache.commons:commons-lang3:3.14.0")
-    implementation("org.xerial:sqlite-jdbc:3.40.1.0")
+    implementation("org.xerial:sqlite-jdbc:3.41.2.2")
     implementation(project(":api"))
 }
 

--- a/core/src/main/java/com/github/rumsfield/konquest/hook/QuickShopHook.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/hook/QuickShopHook.java
@@ -1,12 +1,15 @@
 package com.github.rumsfield.konquest.hook;
 
+import com.ghostchu.quickshop.api.QuickShopProvider;
 import com.github.rumsfield.konquest.Konquest;
 import com.github.rumsfield.konquest.listener.QuickShopListener;
+import com.github.rumsfield.konquest.utility.ChatUtil;
 import com.github.rumsfield.konquest.utility.CorePath;
 import org.bukkit.*;
 import org.bukkit.plugin.Plugin;
+import org.bukkit.plugin.RegisteredServiceProvider;
 import org.jetbrains.annotations.Nullable;
-import org.maxgamer.quickshop.api.QuickShopAPI;
+import com.ghostchu.quickshop.api.QuickShopAPI;
 
 public class QuickShopHook implements PluginHook {
 
@@ -22,14 +25,18 @@ public class QuickShopHook implements PluginHook {
 
 	@Override
 	public String getPluginName() {
-		return "QuickShop";
+		return "QuickShop-Hikari";
 	}
 
 	@Override
 	public int reload() {
 		isEnabled = false;
+		// Check for older QuickShop
+		if (Bukkit.getPluginManager().isPluginEnabled("QuickShop")) {
+			ChatUtil.printConsoleError("Unsupported QuickShop plugin found, install QuickShop-Hikari plugin instead");
+		}
 		// Attempt to integrate QuickShop
-		Plugin quickShop = Bukkit.getPluginManager().getPlugin("QuickShop");
+		Plugin quickShop = Bukkit.getPluginManager().getPlugin("QuickShop-Hikari");
 		if(quickShop == null) {
 			return 1;
 		}
@@ -39,8 +46,12 @@ public class QuickShopHook implements PluginHook {
 		if(!konquest.getCore().getBoolean(CorePath.INTEGRATION_QUICKSHOP.getPath(),false)) {
 			return 3;
 		}
-
-		quickShopAPI = (QuickShopAPI) quickShop;
+		RegisteredServiceProvider<QuickShopProvider> provider = Bukkit.getServicesManager().getRegistration(QuickShopProvider.class);
+		if(provider == null){
+			ChatUtil.printConsoleError("Failed to integrate QuickShop-Hikari, plugin not found or disabled");
+			return -1;
+		}
+		quickShopAPI = provider.getProvider().getApiInstance();
 		isEnabled = true;
 		konquest.getPlugin().getServer().getPluginManager().registerEvents(new QuickShopListener(konquest.getPlugin()), konquest.getPlugin());
 		return 0;

--- a/core/src/main/java/com/github/rumsfield/konquest/listener/QuickShopListener.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/listener/QuickShopListener.java
@@ -28,7 +28,7 @@ public class QuickShopListener implements Listener {
 		if (opPlayer.isPresent()) {
 			boolean status = shopHandler.onShopCreate(event.getLocation(), opPlayer.get());
 			if(!status) {
-				event.setCancelled(true,(String)null);
+				event.setCancelled(true,"Konquest");
 			}
 		}
 	}
@@ -42,7 +42,7 @@ public class QuickShopListener implements Listener {
 		if (opPlayer.isPresent()) {
 			boolean status = shopHandler.onShopUse(event.getShop().getLocation(), opPlayer.get());
 			if (!status) {
-				event.setCancelled(true,(String)null);
+				event.setCancelled(true,"Konquest");
 			}
 		}
 	}
@@ -51,7 +51,7 @@ public class QuickShopListener implements Listener {
 	public void onShopClick(ShopClickEvent event) {
 		boolean status = shopHandler.onShopUse(event.getShop().getLocation(), event.getClicker());
 		if(!status) {
-			event.setCancelled(true,(String)null);
+			event.setCancelled(true,"Konquest");
 		}
 	}
 	

--- a/core/src/main/java/com/github/rumsfield/konquest/listener/QuickShopListener.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/listener/QuickShopListener.java
@@ -1,15 +1,15 @@
 package com.github.rumsfield.konquest.listener;
 
+import com.ghostchu.quickshop.api.event.ShopClickEvent;
 import com.github.rumsfield.konquest.KonquestPlugin;
 import com.github.rumsfield.konquest.shop.ShopHandler;
-import com.github.rumsfield.konquest.utility.ChatUtil;
-import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
-import org.maxgamer.quickshop.api.event.PlayerShopClickEvent;
-import org.maxgamer.quickshop.api.event.ShopPreCreateEvent;
-import org.maxgamer.quickshop.api.event.ShopPurchaseEvent;
+import com.ghostchu.quickshop.api.event.ShopPreCreateEvent;
+import com.ghostchu.quickshop.api.event.ShopPurchaseEvent;
+
+import java.util.Optional;
 
 public class QuickShopListener implements Listener {
 
@@ -24,9 +24,12 @@ public class QuickShopListener implements Listener {
 	 */
 	@EventHandler()
     public void onShopPreCreate(ShopPreCreateEvent event) {
-		boolean status = shopHandler.onShopCreate(event.getLocation(), event.getPlayer());
-		if(!status) {
-			event.setCancelled(true);
+		Optional<Player> opPlayer = event.getCreator().getBukkitPlayer();
+		if (opPlayer.isPresent()) {
+			boolean status = shopHandler.onShopCreate(event.getLocation(), opPlayer.get());
+			if(!status) {
+				event.setCancelled(true,(String)null);
+			}
 		}
 	}
 	
@@ -35,18 +38,20 @@ public class QuickShopListener implements Listener {
 	 */
 	@EventHandler()
     public void onShopPurchase(ShopPurchaseEvent event) {
-		Player purchaser = Bukkit.getPlayer(event.getPurchaser());
-		boolean status = shopHandler.onShopUse(event.getShop().getLocation(), purchaser);
-		if(!status) {
-			event.setCancelled(true);
+		Optional<Player> opPlayer = event.getPurchaser().getBukkitPlayer();
+		if (opPlayer.isPresent()) {
+			boolean status = shopHandler.onShopUse(event.getShop().getLocation(), opPlayer.get());
+			if (!status) {
+				event.setCancelled(true,(String)null);
+			}
 		}
 	}
 
 	@EventHandler()
-	public void onShopClick(PlayerShopClickEvent event) {
-		boolean status = shopHandler.onShopUse(event.getShop().getLocation(), event.getPlayer());
+	public void onShopClick(ShopClickEvent event) {
+		boolean status = shopHandler.onShopUse(event.getShop().getLocation(), event.getClicker());
 		if(!status) {
-			event.setCancelled(true);
+			event.setCancelled(true,(String)null);
 		}
 	}
 	

--- a/core/src/main/java/com/github/rumsfield/konquest/shop/ShopHandler.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/shop/ShopHandler.java
@@ -9,13 +9,11 @@ import com.github.rumsfield.konquest.utility.MessagePath;
 import org.bukkit.*;
 import org.bukkit.block.Sign;
 import org.bukkit.entity.Player;
-import org.maxgamer.quickshop.api.QuickShopAPI;
-import org.maxgamer.quickshop.api.shop.Shop;
+import com.ghostchu.quickshop.api.QuickShopAPI;
+import com.ghostchu.quickshop.api.shop.Shop;
 
 import java.awt.*;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 import java.util.List;
 
 /**
@@ -60,8 +58,10 @@ public class ShopHandler {
                     Map<Location, Shop> shopList = quickshop.getShopManager().getShops(world.getName(), chunkX, chunkZ);
                     if(shopList != null) {
                         for(Map.Entry<Location, Shop> entry : shopList.entrySet()) {
-                            final OfflinePlayer owner = Bukkit.getOfflinePlayer(entry.getValue().getOwner());
-                            entry.getValue().delete();
+                            UUID ownerID = entry.getValue().getOwner().getUniqueId();
+                            assert ownerID != null;
+                            final OfflinePlayer owner = Bukkit.getOfflinePlayer(ownerID);
+                            quickshop.getShopManager().deleteShop(entry.getValue());
                             // Record metrics
                             String ownerName = owner.getName();
                             if(removedShops.containsKey(ownerName)) {

--- a/core/src/main/java/com/github/rumsfield/konquest/utility/ChatUtil.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/utility/ChatUtil.java
@@ -2,7 +2,6 @@ package com.github.rumsfield.konquest.utility;
 
 import com.github.rumsfield.konquest.Konquest;
 import com.github.rumsfield.konquest.model.KonPlayer;
-import me.lucko.helper.config.typeserializers.HelperTypeSerializer;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Color;
@@ -74,32 +73,32 @@ public class ChatUtil {
 	public static String parseFormat(String base, String prefix, String suffix, String kingdom, String rank, String title, String name, String primaryColor, String secondaryColor, String kingdomWebColor) {
 		String message = base;
 		// Tags
-		if(prefix.equals("")) {
+		if(prefix.isEmpty()) {
 			message = message.replaceAll("%PREFIX%\\s*", "");
 		} else {
 			message = message.replace("%PREFIX%", prefix);
 		}
-		if(suffix.equals("")) {
+		if(suffix.isEmpty()) {
 			message = message.replaceAll("%SUFFIX%\\s*", "");
 		} else {
 			message = message.replace("%SUFFIX%", suffix);
 		}
-		if(kingdom.equals("")) {
+		if(kingdom.isEmpty()) {
 			message = message.replaceAll("%KINGDOM%\\s*", "");
 		} else {
 			message = message.replace("%KINGDOM%", kingdom);
 		}
-		if(rank.equals("")) {
+		if(rank.isEmpty()) {
 			message = message.replaceAll("%RANK%\\s*", "");
 		} else {
 			message = message.replace("%RANK%", rank);
 		}
-		if(title.equals("")) {
+		if(title.isEmpty()) {
 			message = message.replaceAll("%TITLE%\\s*", "");
 		} else {
 			message = message.replace("%TITLE%", title);
 		}
-		if(name.equals("")) {
+		if(name.isEmpty()) {
 			message = message.replaceAll("%NAME%\\s*", "");
 		} else {
 			message = message.replace("%NAME%", name);
@@ -363,7 +362,7 @@ public class ChatUtil {
 	}
 	
 	public static void sendKonTitle(KonPlayer player, String title, String subtitle) {
-		if(title.equals("")) {
+		if(title.isEmpty()) {
 			title = " ";
 		}
 		if(!player.isAdminBypassActive() && !player.isPriorityTitleDisplay()) {
@@ -372,7 +371,7 @@ public class ChatUtil {
 	}
 	
 	public static void sendKonTitle(KonPlayer player, String title, String subtitle, int duration) {
-		if(title.equals("")) {
+		if(title.isEmpty()) {
 			title = " ";
 		}
 		if(!player.isAdminBypassActive() && !player.isPriorityTitleDisplay()) {
@@ -381,7 +380,7 @@ public class ChatUtil {
 	}
 	
 	public static void sendKonPriorityTitle(KonPlayer player, String title, String subtitle, int durationTicks, int fadeInTicks, int fadeOutTicks) {
-		if(title.equals("")) {
+		if(title.isEmpty()) {
 			title = " ";
 		}
 		if(!player.isAdminBypassActive() && !player.isPriorityTitleDisplay()) {
@@ -399,7 +398,7 @@ public class ChatUtil {
 	}
 
 	public static void sendConstantTitle(Player player, String title, String subtitle) {
-		if(title.equals("")) {
+		if(title.isEmpty()) {
 			title = " ";
 		}
 		player.sendTitle(title, subtitle, 1, 9999999, 1);

--- a/core/src/main/resources/plugin.yml
+++ b/core/src/main/resources/plugin.yml
@@ -12,6 +12,7 @@ softdepend:
   - ProtocolLib
   - ChestShop
   - QuickShop
+  - QuickShop-Hikari
   - LuckPerms
   - PlaceholderAPI
   - dynmap


### PR DESCRIPTION
# Konquest Pull Request

Closes #262

## Summary
Updates integration support from QuickShop to the newer [QuickShop-Hikari](https://www.spigotmc.org/resources/quickshop-hikari-a-powerful-user-friendly-and-reliable-chestshop-plugin-1-18-2-1-21.100125/) plugin.

## Change Details
* QuickShop-Hikari is a different plugin than QuickShop. Konquest now only supports integration with QuickShop-Hikari.
* Updated dependencies for new plugin support.
* Added check for old QuickShop plugin to throw error message on startup.
* Updated shop handlers with new API methods.

## Checklist
- [x] I have merged the latest `develop` commit into this branch and resolved any conflicts.
- [x] I have tested this branch and it is working as intended.
- [x] This Pull Request is ready for review and merging.