### PR TITLE
Feature/231 peaceful barbarians

### DIFF
--- a/core/src/main/java/com/github/rumsfield/konquest/listener/BlockListener.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/listener/BlockListener.java
@@ -210,6 +210,13 @@ public class BlockListener implements Listener {
 						// Check for enemy player
 						if (playerRole.equals(KonquestRelationshipType.ENEMY)) {
 							// The player is an enemy and may edit blocks
+							// Check for barbarian allowed to attack
+							boolean isBarbarianAttackEnabled = konquest.getCore().getBoolean(CorePath.BARBARIANS_ALLOW_ATTACK_KINGDOMS.getPath(), true);
+							if (player.isBarbarian() && !isBarbarianAttackEnabled) {
+								ChatUtil.sendKonBlockedProtectionTitle(player);
+								event.setCancelled(true);
+								return;
+							}
 							// Check for capital capture conditions
 							if(isCapital && territory.getKingdom().isCapitalImmune()) {
 								// Capital is immune and cannot be attacked
@@ -354,6 +361,13 @@ public class BlockListener implements Listener {
 					}
 					// Prevent group members from breaking beds they don't own
 					if(isMember && !camp.isPlayerOwner(event.getPlayer()) && event.getBlock().getBlockData() instanceof Bed) {
+						ChatUtil.sendKonBlockedProtectionTitle(player);
+						event.setCancelled(true);
+						return;
+					}
+					// Check for barbarian allowed to attack
+					boolean isBarbarianAttackEnabled = konquest.getCore().getBoolean(CorePath.BARBARIANS_ALLOW_ATTACK_CAMPS.getPath(), true);
+					if (player.isBarbarian() && !isBarbarianAttackEnabled) {
 						ChatUtil.sendKonBlockedProtectionTitle(player);
 						event.setCancelled(true);
 						return;

--- a/core/src/main/java/com/github/rumsfield/konquest/listener/BlockListener.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/listener/BlockListener.java
@@ -367,7 +367,7 @@ public class BlockListener implements Listener {
 					}
 					// Check for barbarian allowed to attack
 					boolean isBarbarianAttackEnabled = konquest.getCore().getBoolean(CorePath.BARBARIANS_ALLOW_ATTACK_CAMPS.getPath(), true);
-					if (player.isBarbarian() && !isBarbarianAttackEnabled) {
+					if (player.isBarbarian() && !camp.isPlayerOwner(event.getPlayer()) && !isBarbarianAttackEnabled) {
 						ChatUtil.sendKonBlockedProtectionTitle(player);
 						event.setCancelled(true);
 						return;

--- a/core/src/main/java/com/github/rumsfield/konquest/listener/EntityListener.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/listener/EntityListener.java
@@ -846,6 +846,7 @@ public class EntityListener implements Listener {
 			boolean isFlagArenaAllowed = konquest.getIntegrationManager().getWorldGuard().isLocationArenaAllowed(victimBukkitPlayer.getLocation(),attackerBukkitPlayer);
 
 			// Check for kingdom relationships
+			boolean isBarbarianPvpEnabled = konquest.getCore().getBoolean(CorePath.BARBARIANS_ALLOW_PVP.getPath(), true);
 			boolean isAllDamageEnabled = konquest.getCore().getBoolean(CorePath.KINGDOMS_ALLOW_ALL_PVP.getPath(), false);
 			boolean isPeaceDamageEnabled = konquest.getCore().getBoolean(CorePath.KINGDOMS_ALLOW_PEACEFUL_PVP.getPath(), false);
 			boolean isPlayerEnemy = true;
@@ -875,6 +876,12 @@ public class EntityListener implements Listener {
 				}
 				// Protect pvp when property is false
 				if (isPropertyPvpProtected) {
+					ChatUtil.sendKonBlockedFlagTitle(attackerPlayer);
+					event.setCancelled(true);
+					return;
+				}
+				// Protect victim when attacker is barbarian and pvp is not allowed
+				if (attackerPlayer.isBarbarian() && !isBarbarianPvpEnabled) {
 					ChatUtil.sendKonBlockedFlagTitle(attackerPlayer);
 					event.setCancelled(true);
 					return;

--- a/core/src/main/java/com/github/rumsfield/konquest/listener/EntityListener.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/listener/EntityListener.java
@@ -880,9 +880,9 @@ public class EntityListener implements Listener {
 					event.setCancelled(true);
 					return;
 				}
-				// Protect victim when attacker is barbarian and pvp is not allowed
-				if (attackerPlayer.isBarbarian() && !isBarbarianPvpEnabled) {
-					ChatUtil.sendKonBlockedFlagTitle(attackerPlayer);
+				// Protect against barbarian pvp
+				if (!isBarbarianPvpEnabled && (attackerPlayer.isBarbarian() || victimPlayer.isBarbarian())) {
+					ChatUtil.sendKonBlockedProtectionTitle(attackerPlayer);
 					event.setCancelled(true);
 					return;
 				}

--- a/core/src/main/java/com/github/rumsfield/konquest/utility/CorePath.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/utility/CorePath.java
@@ -167,7 +167,11 @@ public enum CorePath {
 	PLOTS_ALLOW_BUILD                                     ("core.plots.allow_build"),
 	PLOTS_ALLOW_CONTAINERS                                ("core.plots.allow_containers"),
 	PLOTS_IGNORE_KNIGHTS                                  ("core.plots.ignore_knights"),
-	
+
+	BARBARIANS_ALLOW_ATTACK_KINGDOMS                      ("core.barbarians.allow_attack_kingdoms"),
+	BARBARIANS_ALLOW_ATTACK_CAMPS                         ("core.barbarians.allow_attack_camps"),
+	BARBARIANS_ALLOW_PVP                                  ("core.barbarians.allow_pvp"),
+
 	EXILE_REMOVE_FAVOR                                    ("core.exile.remove_favor"),
 	EXILE_REMOVE_STATS                                    ("core.exile.remove_stats"),
 	EXILE_TELEPORT_WILD                                   ("core.exile.teleport_wild"),

--- a/core/src/main/resources/core.yml
+++ b/core/src/main/resources/core.yml
@@ -556,7 +556,19 @@ core:
     
     # Allow town knights to ignore plot protections (true/false)
     ignore_knights: true
-    
+
+  # //// CORE.BARBARIANS \\\\
+  barbarians:
+
+    # Allow barbarian players to modify blocks inside town land (true/false)
+    allow_attack_kingdoms: true
+
+    # Allow barbarian players to modify blocks inside other barbarian camps (true/false)
+    allow_attack_camps: true
+
+    # Allow barbarian players to damage other players (true/false)
+    allow_pvp: true
+
   # //// CORE.EXILE \\\\
   exile:
     


### PR DESCRIPTION
# Konquest Pull Request

Closes #231

## Summary
Adds core.yml config options to prevent barbarians from attacking towns and camps, and from pvp.

## Change Details
Added the following core options
* `core.barbarians.allow_attack_kingdoms` - Allow barbarian players to modify blocks inside town land
* `core.barbarians.allow_attack_camps` - Allow barbarian players to modify blocks inside other barbarian camps
* `core.barbarians.allow_pvp` - Allow barbarian players to damage other players

## Checklist
- [x] I have merged the latest `develop` commit into this branch and resolved any conflicts.
- [x] I have tested this branch and it is working as intended.
- [x] This Pull Request is ready for review and merging.