### PR TITLE
Bugfix/282 golem search radius

### DIFF
--- a/core/src/main/java/com/github/rumsfield/konquest/Konquest.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/Konquest.java
@@ -229,6 +229,7 @@ public class Konquest implements KonquestAPI, Timeable {
 		ruinManager.regenAllRuins();
 		ruinManager.removeAllGolems();
 		kingdomManager.removeAllRabbits();
+		playerManager.clearAllMobTargets();
 		configManager.saveConfigs();
 		databaseThread.flushDatabase();
 		databaseThread.getDatabase().getDatabaseConnection().disconnect();

--- a/core/src/main/java/com/github/rumsfield/konquest/listener/EntityListener.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/listener/EntityListener.java
@@ -739,12 +739,10 @@ public class EntityListener implements Listener {
     					// Iron Golem lives
 	    				LivingEntity currentTarget = golem.getTarget();
 	    				if(currentTarget instanceof Player) {
-	    					if(!konquest.getPlayerManager().isOnlinePlayer((Player)currentTarget)) {
-	    						ChatUtil.printDebug("Failed to handle onEntityDamageByPlayer golem targeting for non-existent player");
-	    					} else {
-		    					KonPlayer previousTargetPlayer = playerManager.getPlayer((Player)currentTarget);
-		    					previousTargetPlayer.removeMobAttacker(golem);
-	    					}
+							KonPlayer previousTargetPlayer = playerManager.getPlayer((Player)currentTarget);
+							if (previousTargetPlayer != null) {
+								previousTargetPlayer.removeMobAttacker(golem);
+							}
 	    				}
 	    				golem.setTarget(bukkitPlayer);
 	    				player.addMobAttacker(golem);

--- a/core/src/main/java/com/github/rumsfield/konquest/manager/PlayerManager.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/manager/PlayerManager.java
@@ -489,4 +489,10 @@ public class PlayerManager implements KonquestPlayerManager {
 		return new HashSet<>(onlinePlayers.keySet());
 	}
 
+	public void clearAllMobTargets() {
+		for (KonPlayer player : onlinePlayers.values()) {
+			player.clearAllMobAttackers();
+		}
+	}
+
 }

--- a/core/src/main/java/com/github/rumsfield/konquest/model/KonPlayer.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/model/KonPlayer.java
@@ -115,8 +115,11 @@ public class KonPlayer extends KonOfflinePlayer implements KonquestPlayer, Timea
 		}
 	}
 	
-	public boolean removeMobAttacker(Mob mob) {
-		return targetMobList.remove(mob);
+	public void removeMobAttacker(Mob mob) {
+		if(targetMobList.contains(mob)) {
+			mob.setTarget(null);
+			targetMobList.remove(mob);
+		}
 	}
 	
 	public void clearAllMobAttackers() {

--- a/core/src/main/java/com/github/rumsfield/konquest/model/KonTown.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/model/KonTown.java
@@ -1256,6 +1256,8 @@ public class KonTown extends KonTerritory implements KonquestTown, KonBarDisplay
 			if (!isLocInside(golem.getLocation()) && getKonquest().getTerritoryManager().isChunkClaimed(golem.getLocation())) {
 				continue;
 			}
+			// Force player-created to make targeting easy to work with
+			golem.setPlayerCreated(true);
 			// Check for closest enemy player inside of town
 			boolean isNearbyPlayer = false;
 			double minDistance = 99;


### PR DESCRIPTION
# Konquest Pull Request

Closes #282

## Summary
Updates the iron golem targeting logic for towns to used smaller fixed radius for the entity search rather than depending on the town max size, which can be very large.

Now, when enemy players enter a town, iron golems within 12 chunks of the town center, and within 8 chunks of the enemy player, will try to target enemy players nearby.

## Checklist
- [x] I have merged the latest `develop` commit into this branch and resolved any conflicts.
- [x] I have tested this branch and it is working as intended.
- [x] This Pull Request is ready for review and merging.