### PR TITLE
Added ready check in hook reload #331

### DIFF
--- a/core/src/main/java/com/github/rumsfield/konquest/hook/DiscordSrvHook.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/hook/DiscordSrvHook.java
@@ -81,7 +81,11 @@ public class DiscordSrvHook implements PluginHook {
 			return 3;
 		}
 		try {
+			// Subscribe listener
 			DiscordSRV.api.subscribe(discordSrvListener);
+			// Check for ready
+			isDiscordReady = DiscordSRV.isReady;
+			// Enable hook
 			isEnabled = true;
 			reloadSettings();
 			return 0;


### PR DESCRIPTION
# Konquest Pull Request

Closes #331

## Summary
Adds query for DiscordSRV is ready when hook is reloaded, to handle case where Discord SRV is already thrown the ready event by the time Konquest initializes. See issue for some errors thrown in DiscordSRV - these appear to be problems with their API, not Konquest.

## Checklist
- [x] I have merged the latest `develop` commit into this branch and resolved any conflicts.
- [x] I have tested this branch and it is working as intended.
- [x] This Pull Request is ready for review and merging.