### PR TITLE
Feature/335 minecraft 1.21.6

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 dependencies{
-    compileOnly("org.spigotmc:spigot-api:1.21.5-R0.1-SNAPSHOT") // Primary API
+    compileOnly("org.spigotmc:spigot-api:1.21.6-R0.1-SNAPSHOT") // Primary API
 }
 
 tasks {

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -43,7 +43,7 @@ repositories{
 
 dependencies{
     // Spigot
-    compileOnly("org.spigotmc:spigot-api:1.21.5-R0.1-SNAPSHOT") // Primary API
+    compileOnly("org.spigotmc:spigot-api:1.21.6-R0.1-SNAPSHOT") // Primary API
     compileOnly("org.spigotmc:spigot-1.17.1-R0.1-SNAPSHOT-remapped") // for nms packets, local lib
     compileOnly("org.spigotmc:spigot-1.16.5-R0.1-SNAPSHOT") // for nms packets, local lib
 

--- a/core/src/main/java/com/github/rumsfield/konquest/Konquest.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/Konquest.java
@@ -273,7 +273,7 @@ public class Konquest implements KonquestAPI, Timeable {
 				isVersionSupported = true;
 				if(isProtocolLibEnabled) { versionHandler = new Handler_1_18_R2(); }
 
-			} else if (CompatibilityUtil.apiVersion.compareTo(new Version("1.21.5")) <= 0) {
+			} else if (CompatibilityUtil.apiVersion.compareTo(new Version("1.21.6")) <= 0) {
 				isVersionSupported = true;
 				if(isProtocolLibEnabled) { versionHandler = new Handler_1_19_R1(); }
 


### PR DESCRIPTION
# Konquest Pull Request

Closes #335

## Summary
Updates primary Spigot API to 1.21.6, adds support for Minecraft 1.21.6.

## Checklist
- [x] I have merged the latest `develop` commit into this branch and resolved any conflicts.
- [x] I have tested this branch and it is working as intended.
- [x] This Pull Request is ready for review and merging.