### PR TITLE
Feature/334 raid alert control

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -66,7 +66,7 @@ dependencies{
     compileOnly("net.essentialsx:EssentialsX:2.20.1")
     compileOnly("xyz.jpenilla:squaremap-api:1.3.4")
 
-    implementation("org.apache.commons:commons-lang3:3.14.0")
+    implementation("org.apache.commons:commons-lang3:3.17.0")
     implementation("org.xerial:sqlite-jdbc:3.41.2.2")
     implementation(project(":api"))
 }

--- a/core/src/main/java/com/github/rumsfield/konquest/listener/BlockListener.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/listener/BlockListener.java
@@ -1489,7 +1489,8 @@ public class BlockListener implements Listener {
 			// Execute custom commands from config
 			konquest.executeCustomCommand(CustomCommandPath.TOWN_MONUMENT_CRITICAL,player.getBukkitPlayer());
 			// Alert all players of enemy Kingdom when the first critical block is broken
-			if(town.getMonument().getCriticalHits() == 1) {
+			boolean isPerm1 = player.getBukkitPlayer().hasPermission("konquest.raid.critical1");
+			if(town.getMonument().getCriticalHits() == 1 && isPerm1) {
 				for(KonPlayer kingdomPlayer : playerManager.getPlayersInKingdom(kingdomName)) {
 					ChatUtil.sendKonPriorityTitle(kingdomPlayer, ChatColor.DARK_RED+MessagePath.PROTECTION_NOTICE_RAID_ALERT.getMessage(), ChatColor.DARK_RED+""+town.getName(), 60, 1, 10);
 					ChatUtil.sendNotice(kingdomPlayer.getBukkitPlayer(), MessagePath.PROTECTION_NOTICE_RAID_CAPTURE_1.getMessage(town.getName(),town.getTravelName(),defendReward),ChatColor.DARK_RED);
@@ -1501,14 +1502,16 @@ public class BlockListener implements Listener {
 				}
 			}
 			// Alert all players of enemy Kingdom when half of critical blocks are broken
-			if(town.getMonument().getCriticalHits() == maxCriticalhits/2) {
+			boolean isPerm2 = player.getBukkitPlayer().hasPermission("konquest.raid.critical2");
+			if(town.getMonument().getCriticalHits() == maxCriticalhits/2 && isPerm2) {
 				for(KonPlayer kingdomPlayer : playerManager.getPlayersInKingdom(kingdomName)) {
 					ChatUtil.sendKonPriorityTitle(kingdomPlayer, ChatColor.DARK_RED+MessagePath.PROTECTION_NOTICE_RAID_ALERT.getMessage(), ChatColor.DARK_RED+""+town.getName(), 60, 1, 10);
 					ChatUtil.sendNotice(kingdomPlayer.getBukkitPlayer(), MessagePath.PROTECTION_NOTICE_RAID_CAPTURE_2.getMessage(town.getName(),town.getTravelName(),defendReward),ChatColor.DARK_RED);
 				}
 			}
 			// Alert all players of enemy Kingdom when all but 1 critical blocks are broken
-			if(town.getMonument().getCriticalHits() == maxCriticalhits-1) {
+			boolean isPerm3 = player.getBukkitPlayer().hasPermission("konquest.raid.critical3");
+			if(town.getMonument().getCriticalHits() == maxCriticalhits-1 && isPerm3) {
 				for(KonPlayer kingdomPlayer : playerManager.getPlayersInKingdom(kingdomName)) {
 					ChatUtil.sendKonPriorityTitle(kingdomPlayer, ChatColor.DARK_RED+MessagePath.PROTECTION_NOTICE_RAID_ALERT.getMessage(), ChatColor.DARK_RED+""+town.getName(), 60, 1, 10);
 					ChatUtil.sendNotice(kingdomPlayer.getBukkitPlayer(), MessagePath.PROTECTION_NOTICE_RAID_CAPTURE_3.getMessage(town.getName(),town.getTravelName(),defendReward),ChatColor.DARK_RED);

--- a/core/src/main/java/com/github/rumsfield/konquest/listener/BlockListener.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/listener/BlockListener.java
@@ -1489,7 +1489,7 @@ public class BlockListener implements Listener {
 			// Execute custom commands from config
 			konquest.executeCustomCommand(CustomCommandPath.TOWN_MONUMENT_CRITICAL,player.getBukkitPlayer());
 			// Alert all players of enemy Kingdom when the first critical block is broken
-			boolean isPerm1 = player.getBukkitPlayer().hasPermission("konquest.raid.critical1");
+			boolean isPerm1 = player.getBukkitPlayer().hasPermission("konquest.raid.first");
 			if(town.getMonument().getCriticalHits() == 1 && isPerm1) {
 				for(KonPlayer kingdomPlayer : playerManager.getPlayersInKingdom(kingdomName)) {
 					ChatUtil.sendKonPriorityTitle(kingdomPlayer, ChatColor.DARK_RED+MessagePath.PROTECTION_NOTICE_RAID_ALERT.getMessage(), ChatColor.DARK_RED+""+town.getName(), 60, 1, 10);
@@ -1502,7 +1502,7 @@ public class BlockListener implements Listener {
 				}
 			}
 			// Alert all players of enemy Kingdom when half of critical blocks are broken
-			boolean isPerm2 = player.getBukkitPlayer().hasPermission("konquest.raid.critical2");
+			boolean isPerm2 = player.getBukkitPlayer().hasPermission("konquest.raid.half");
 			if(town.getMonument().getCriticalHits() == maxCriticalhits/2 && isPerm2) {
 				for(KonPlayer kingdomPlayer : playerManager.getPlayersInKingdom(kingdomName)) {
 					ChatUtil.sendKonPriorityTitle(kingdomPlayer, ChatColor.DARK_RED+MessagePath.PROTECTION_NOTICE_RAID_ALERT.getMessage(), ChatColor.DARK_RED+""+town.getName(), 60, 1, 10);
@@ -1510,7 +1510,7 @@ public class BlockListener implements Listener {
 				}
 			}
 			// Alert all players of enemy Kingdom when all but 1 critical blocks are broken
-			boolean isPerm3 = player.getBukkitPlayer().hasPermission("konquest.raid.critical3");
+			boolean isPerm3 = player.getBukkitPlayer().hasPermission("konquest.raid.last");
 			if(town.getMonument().getCriticalHits() == maxCriticalhits-1 && isPerm3) {
 				for(KonPlayer kingdomPlayer : playerManager.getPlayersInKingdom(kingdomName)) {
 					ChatUtil.sendKonPriorityTitle(kingdomPlayer, ChatColor.DARK_RED+MessagePath.PROTECTION_NOTICE_RAID_ALERT.getMessage(), ChatColor.DARK_RED+""+town.getName(), 60, 1, 10);

--- a/core/src/main/java/com/github/rumsfield/konquest/listener/PlayerListener.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/listener/PlayerListener.java
@@ -1312,7 +1312,8 @@ public class PlayerListener implements Listener {
 		} else if(territoryTo instanceof KonCamp) {
 			KonCamp camp = (KonCamp)territoryTo;
 			// Attempt to start a raid alert
-			if(!camp.isRaidAlertDisabled() && !player.isAdminBypassActive() && !player.getKingdom().isPeaceful()) {
+			boolean isPerm = player.getBukkitPlayer().hasPermission("konquest.raid.entry");
+			if(!camp.isRaidAlertDisabled() && !player.isAdminBypassActive() && !player.getKingdom().isPeaceful() && isPerm) {
 				// Verify online player
 				if(camp.isOwnerOnline()) {
 					boolean isMember = false;

--- a/core/src/main/java/com/github/rumsfield/konquest/model/KonTown.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/model/KonTown.java
@@ -1191,7 +1191,8 @@ public class KonTown extends KonTerritory implements KonquestTown, KonBarDisplay
 	
 	public void sendRaidAlert(KonPlayer attacker) {
 		// Attempt to start a raid alert
-		if(!isRaidAlertDisabled()) {
+		boolean isPerm = attacker.getBukkitPlayer().hasPermission("konquest.raid.entry");
+		if(!isRaidAlertDisabled() && isPerm) {
 			// Alert all players of this town's kingdom
 			for(KonPlayer player : getKonquest().getPlayerManager().getPlayersInKingdom(getKingdom().getName())) {
 				if(!player.isAdminBypassActive() && !player.getBukkitPlayer().getGameMode().equals(GameMode.SPECTATOR)) {

--- a/core/src/main/resources/plugin.yml
+++ b/core/src/main/resources/plugin.yml
@@ -5,8 +5,6 @@ version: @version@
 api-version: 1.16
 load: POSTWORLD
 main: com.github.rumsfield.konquest.KonquestPlugin
-libraries:
-  - org.apache.commons:commons-lang3:3.14.0
 depend: [Vault]
 softdepend:
   - ProtocolLib
@@ -346,3 +344,19 @@ permissions:
   konquest.chatcolor:
     description: Allows players to use color format codes in chat messages
     default: false
+
+  konquest.raid.entry:
+    description: Enables raid alerts upon entering enemy territory
+    default: true
+
+  konquest.raid.critical1:
+    description: Enables raid alerts on first critical block break
+    default: true
+
+  konquest.raid.critical2:
+    description: Enables raid alerts on half of total critical block break
+    default: true
+
+  konquest.raid.critical3:
+    description: Enables raid alerts on second to last critical block break
+    default: true

--- a/core/src/main/resources/plugin.yml
+++ b/core/src/main/resources/plugin.yml
@@ -349,14 +349,14 @@ permissions:
     description: Enables raid alerts upon entering enemy territory
     default: true
 
-  konquest.raid.critical1:
-    description: Enables raid alerts on first critical block break
+  konquest.raid.first:
+    description: Enables raid alerts on first critical block break in town monuments
     default: true
 
-  konquest.raid.critical2:
-    description: Enables raid alerts on half of total critical block break
+  konquest.raid.half:
+    description: Enables raid alerts on half of total critical block break in town monuments
     default: true
 
-  konquest.raid.critical3:
-    description: Enables raid alerts on second to last critical block break
+  konquest.raid.last:
+    description: Enables raid alerts on second to last critical block break in town monuments
     default: true


### PR DESCRIPTION
# Konquest Pull Request

Closes #334 

## Summary
Adds permissions to control how raid alert messages are caused.

## Change Details
Adds the following permissions, all true for the default group.
* `konquest.raid.entry` - Enables raid alerts upon entering enemy territory
* `konquest.raid.first` - Enables raid alerts on first critical block break in town monuments
* `konquest.raid.half` - Enables raid alerts on half of total critical block break in town monuments
* `konquest.raid.last` - Enables raid alerts on second to last critical block break in town monuments

## Checklist
- [x] I have merged the latest `develop` commit into this branch and resolved any conflicts.
- [x] I have tested this branch and it is working as intended.
- [x] This Pull Request is ready for review and merging.