### PR TITLE
Feature/245 forced town options

### DIFF
--- a/core/src/main/java/com/github/rumsfield/konquest/command/TownCommand.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/command/TownCommand.java
@@ -723,6 +723,8 @@ public class TownCommand extends CommandBase {
 				}
 			}
 		} else if (numArgs == 4) {
+			String townName = args.get(1);
+			KonTown town;
 			switch (args.get(2).toLowerCase()) {
 				case "rename":
 					tabList.add("***");
@@ -756,17 +758,19 @@ public class TownCommand extends CommandBase {
 					}
 					break;
 				case "option":
+					town = kingdom.getTownCapital(townName);
+					if (town == null) return Collections.emptyList();
 					for (KonTownOption option : KonTownOption.values()) {
-						tabList.add(option.toString());
+						if (!town.isTownOptionOverridden(option)) {
+							tabList.add(option.toString());
+						}
 					}
 					break;
 				case "requests":
-					String townName = args.get(1);
-					KonTown town = kingdom.getTownCapital(townName);
-					if (town != null) {
-						for (OfflinePlayer requester : town.getJoinRequests()) {
-							tabList.add(requester.getName());
-						}
+					town = kingdom.getTownCapital(townName);
+					if (town == null) return Collections.emptyList();
+					for (OfflinePlayer requester : town.getJoinRequests()) {
+						tabList.add(requester.getName());
 					}
 					break;
 				case "resident":

--- a/core/src/main/java/com/github/rumsfield/konquest/command/admin/TownAdminCommand.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/command/admin/TownAdminCommand.java
@@ -650,6 +650,7 @@ public class TownAdminCommand extends CommandBase {
 	@Override
 	public List<String> tabComplete(Konquest konquest, CommandSender sender, List<String> args) {
 		List<String> tabList = new ArrayList<>();
+		KonTown town;
 		int numArgs = args.size();
 		if (numArgs == 1) {
 			// suggest sub-commands
@@ -713,8 +714,12 @@ public class TownAdminCommand extends CommandBase {
 					}
 					break;
 				case "option":
+					town = konquest.getKingdomManager().getTownCapital(args.get(1));
+					if (town == null) return Collections.emptyList();
 					for (KonTownOption option : KonTownOption.values()) {
-						tabList.add(option.toString());
+						if (!town.isTownOptionOverridden(option)) {
+							tabList.add(option.toString());
+						}
 					}
 					break;
 				case "shield":
@@ -755,8 +760,7 @@ public class TownAdminCommand extends CommandBase {
 					tabList.add("false");
 					break;
 				case "resident":
-					String townName = args.get(1);
-					KonTown town = konquest.getKingdomManager().getTownCapital(townName);
+					town = konquest.getKingdomManager().getTownCapital(args.get(1));
 					if (town == null) return Collections.emptyList();
 					switch (args.get(2).toLowerCase()) {
 						case "add":

--- a/core/src/main/java/com/github/rumsfield/konquest/display/menu/TownMenu.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/display/menu/TownMenu.java
@@ -660,6 +660,9 @@ public class TownMenu extends StateMenu {
             if (townOption.equals(KonTownOption.ALLIED_BUILDING)) {
                 isOptionEnabled = getKonquest().getCore().getBoolean(CorePath.KINGDOMS_ALLY_BUILD.getPath(),false);
             }
+            if (town.isTownOptionOverridden(townOption)) {
+                isOptionEnabled = false;
+            }
             if (isOptionEnabled) {
                 allOptions.add(townOption);
             }

--- a/core/src/main/java/com/github/rumsfield/konquest/manager/ConfigManager.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/manager/ConfigManager.java
@@ -59,6 +59,8 @@ public class ConfigManager{
 		updateConfigVersion("prefix");
 		addConfig("commands", new KonConfig("commands",false));
 		updateConfigVersion("commands");
+		addConfig("town-options", new KonConfig("town-options",false));
+		updateConfigVersion("town-options");
 
 		// Data Storage
 		migrateConfigFile("kingdoms.yml","data/kingdoms.yml");

--- a/core/src/main/java/com/github/rumsfield/konquest/manager/KingdomManager.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/manager/KingdomManager.java
@@ -55,6 +55,7 @@ public class KingdomManager implements KonquestKingdomManager, Timeable {
 	private final HashMap<UUID,Integer> exilePlayerCooldowns;
 	private final ArrayList<DiplomacyTicket> diplomacyTickets;
 	private boolean isKingdomDataNull;
+	private final Timer payTimer;
 
 	// Global Event features
 	private boolean isGlobalEventWar;
@@ -85,8 +86,6 @@ public class KingdomManager implements KonquestKingdomManager, Timeable {
 	private boolean townDestroyLordEnable;
 	private boolean townDestroyMasterEnable;
 	private boolean townPurchaseEnable;
-
-	private final Timer payTimer;
 	
 	public KingdomManager(Konquest konquest) {
 		this.konquest = konquest;
@@ -191,6 +190,10 @@ public class KingdomManager implements KonquestKingdomManager, Timeable {
 		discountStack			= konquest.getCore().getBoolean(CorePath.TOWNS_DISCOUNT_STACK.getPath());
 		discountPercent 		= Math.max(discountPercent,0);
 		discountPercent 		= Math.min(discountPercent,100);
+
+		// Forced Town Options
+
+
 	}
 
 	public String getKingdomPayTime() {
@@ -3567,6 +3570,11 @@ public class KingdomManager implements KonquestKingdomManager, Timeable {
 		if (!isTownOptionFeatureEnabled(option)) {
 			// Cannot set this option
 			ChatUtil.sendError(messageSender, MessagePath.GENERIC_ERROR_DISABLED.getMessage());
+			return false;
+		}
+		// Check for overrides
+		if (town.isTownOptionOverridden(option)) {
+			ChatUtil.sendError(messageSender, MessagePath.GENERIC_ERROR_NO_ALLOW.getMessage());
 			return false;
 		}
 		// Set option

--- a/core/src/main/java/com/github/rumsfield/konquest/manager/KingdomManager.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/manager/KingdomManager.java
@@ -191,9 +191,38 @@ public class KingdomManager implements KonquestKingdomManager, Timeable {
 		discountPercent 		= Math.max(discountPercent,0);
 		discountPercent 		= Math.min(discountPercent,100);
 
-		// Forced Town Options
-
-
+		// Town Option Overrides
+		for (KonKingdom kingdom : getKingdoms()) {
+			for (KonTown townCapital : kingdom.getCapitalTowns()) {
+				townCapital.refreshOptionOverrides();
+			}
+		}
+		boolean showOptionList = false;
+		FileConfiguration townOptionsConfig = konquest.getConfigManager().getConfig("town-options");
+		ConfigurationSection rootSection = townOptionsConfig.getConfigurationSection("town-options");
+		if (rootSection != null) {
+			for(String townSectionName : rootSection.getKeys(false)) {
+				if (townSectionName.equals("global") || isTown(townSectionName) || isCapital(townSectionName)) {
+					// Check for valid keys
+					for(String optionName : rootSection.getConfigurationSection(townSectionName).getKeys(false)) {
+						if (KonTownOption.getOption(optionName) == null) {
+							ChatUtil.printConsoleError("Invalid option \""+optionName+"\" for entry \""+townSectionName+"\" in town-options.yml, must match a Town Option.");
+							showOptionList = true;
+						}
+					}
+				} else {
+					// Entry is not a valid town name
+					ChatUtil.printConsoleError("Invalid entry \""+townSectionName+"\" in town-options.yml, must match a town name, kingdom name, or global.");
+				}
+			}
+			if (showOptionList) {
+				ArrayList<String> optionNames = new ArrayList<>();
+				for (KonTownOption option : KonTownOption.values()) {
+					optionNames.add(option.toString());
+				}
+				ChatUtil.printConsoleError("Town Option names are: "+HelperUtil.formatCommaSeparatedList(optionNames));
+			}
+		}
 	}
 
 	public String getKingdomPayTime() {

--- a/core/src/main/java/com/github/rumsfield/konquest/model/KonTown.java
+++ b/core/src/main/java/com/github/rumsfield/konquest/model/KonTown.java
@@ -13,6 +13,8 @@ import org.bukkit.block.Block;
 import org.bukkit.block.Container;
 import org.bukkit.boss.BarStyle;
 import org.bukkit.boss.BossBar;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.entity.*;
 import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.inventory.*;
@@ -52,6 +54,7 @@ public class KonTown extends KonTerritory implements KonquestTown, KonBarDisplay
 	private final HashMap<UUID,Double> purchaseOffers;
 	private RequestKeeper joinRequestKeeper;
 	private final HashMap<KonTownOption,Boolean> townOptions;
+	private final HashMap<KonTownOption,Boolean> townOptionsOverride;
 	private boolean isAttacked;
 	private boolean isShielded;
 	private boolean isShieldFreeEvent;
@@ -126,6 +129,7 @@ public class KonTown extends KonTerritory implements KonquestTown, KonBarDisplay
 		this.disabledUpgrades = new HashMap<>();
 		this.plots = new HashMap<>();
 		this.townOptions = new HashMap<>();
+		this.townOptionsOverride = new HashMap<>();
 		initOptions();
 		this.properties = new HashMap<>();
 		initProperties();
@@ -157,6 +161,7 @@ public class KonTown extends KonTerritory implements KonquestTown, KonBarDisplay
 		for (KonTownOption option : townOptions.keySet()) {
 			copyTown.setTownOption(option, townOptions.get(option));
 		}
+		copyTown.refreshOptionOverrides();
 		// Set properties
 		for (KonPropertyFlag flag : properties.keySet()) {
 			copyTown.setPropertyValue(flag, properties.get(flag));
@@ -175,6 +180,40 @@ public class KonTown extends KonTerritory implements KonquestTown, KonBarDisplay
 		townOptions.clear();
 		for (KonTownOption option : KonTownOption.values()) {
 			townOptions.put(option,option.getDefaultValue());
+		}
+		refreshOptionOverrides();
+	}
+
+	public void refreshOptionOverrides() {
+		townOptionsOverride.clear();
+		FileConfiguration townOptionsConfig = getKonquest().getConfigManager().getConfig("town-options");
+		if (townOptionsConfig.get("town-options") == null) return;
+		// Check for globals
+		ConfigurationSection globalSection = townOptionsConfig.getConfigurationSection("town-options.global");
+		if (globalSection != null) {
+			// Global section exists
+			for(String globalOptionName : globalSection.getKeys(false)) {
+				KonTownOption globalOptionOverride = KonTownOption.getOption(globalOptionName);
+				if (globalOptionOverride != null) {
+					// Add option override
+					boolean optionValue = globalSection.getBoolean(globalOptionName);
+					townOptionsOverride.put(globalOptionOverride, optionValue);
+				}
+			}
+		}
+		// Check for town name
+		String sectionName = (this instanceof KonCapital) ? this.getKingdom().getName() : this.getName();
+		ConfigurationSection townSection = townOptionsConfig.getConfigurationSection("town-options."+sectionName);
+		if (townSection != null) {
+			// Town section exists
+			for(String townOptionName : townSection.getKeys(false)) {
+				KonTownOption townOptionOverride = KonTownOption.getOption(townOptionName);
+				if (townOptionOverride != null) {
+					// Add option override
+					boolean optionValue = townSection.getBoolean(townOptionName);
+					townOptionsOverride.put(townOptionOverride, optionValue);
+				}
+			}
 		}
 	}
 
@@ -1323,11 +1362,21 @@ public class KonTown extends KonTerritory implements KonquestTown, KonBarDisplay
 		Town Options
 	 */
 
+	public boolean isTownOptionOverridden(KonTownOption option) {
+		return townOptionsOverride.containsKey(option);
+	}
+
 	public boolean setTownOption(KonTownOption option, boolean value) {
 		if (townOptions.containsKey(option)) {
-			// Set valid option
-			townOptions.put(option,value);
-			return true;
+			// Option is valid
+			if (townOptionsOverride.containsKey(option)) {
+				// Option is overridden
+				return false;
+			} else {
+				// Set valid option
+				townOptions.put(option,value);
+				return true;
+			}
 		}
 		// No valid option
 		return false;
@@ -1335,8 +1384,8 @@ public class KonTown extends KonTerritory implements KonquestTown, KonBarDisplay
 
 	public boolean getTownOption(KonTownOption option) {
 		if (townOptions.containsKey(option)) {
-			// Get valid option
-			return townOptions.get(option);
+			// Option is valid
+			return townOptionsOverride.containsKey(option) ? townOptionsOverride.get(option) : townOptions.get(option);
 		}
 		// No valid option
 		return false;
@@ -1344,51 +1393,51 @@ public class KonTown extends KonTerritory implements KonquestTown, KonBarDisplay
 
 	/* Legacy Methods */
 	public void setIsOpen(boolean val) {
-		townOptions.put(KonTownOption.OPEN,val);
+		setTownOption(KonTownOption.OPEN,val);
 	}
 	
 	public boolean isOpen() {
-		return townOptions.get(KonTownOption.OPEN);
+		return getTownOption(KonTownOption.OPEN);
 	}
 
 	public void setIsAlliedBuildingAllowed(boolean val) {
-		townOptions.put(KonTownOption.ALLIED_BUILDING,val);
+		setTownOption(KonTownOption.ALLIED_BUILDING,val);
 	}
 
 	public boolean isAlliedBuildingAllowed() {
-		return townOptions.get(KonTownOption.ALLIED_BUILDING);
+		return getTownOption(KonTownOption.ALLIED_BUILDING);
 	}
 
 	public void setIsFriendlyRedstoneAllowed(boolean val) {
-		townOptions.put(KonTownOption.FRIENDLY_REDSTONE,val);
+		setTownOption(KonTownOption.FRIENDLY_REDSTONE,val);
 	}
 
 	public boolean isFriendlyRedstoneAllowed() {
-		return townOptions.get(KonTownOption.FRIENDLY_REDSTONE);
+		return getTownOption(KonTownOption.FRIENDLY_REDSTONE);
 	}
 
 	public void setIsEnemyRedstoneAllowed(boolean val) {
-		townOptions.put(KonTownOption.ENEMY_REDSTONE,val);
+		setTownOption(KonTownOption.ENEMY_REDSTONE,val);
 	}
 	
 	public boolean isEnemyRedstoneAllowed() {
-		return townOptions.get(KonTownOption.ENEMY_REDSTONE);
+		return getTownOption(KonTownOption.ENEMY_REDSTONE);
 	}
 	
 	public void setIsPlotOnly(boolean val) {
-		townOptions.put(KonTownOption.PLOTS_ONLY,val);
+		setTownOption(KonTownOption.PLOTS_ONLY,val);
 	}
 	
 	public boolean isPlotOnly() {
-		return townOptions.get(KonTownOption.PLOTS_ONLY);
+		return getTownOption(KonTownOption.PLOTS_ONLY);
 	}
 	
 	public void setIsGolemOffensive(boolean val) {
-		townOptions.put(KonTownOption.GOLEM_OFFENSE,val);
+		setTownOption(KonTownOption.GOLEM_OFFENSE,val);
 	}
 	
 	public boolean isGolemOffensive() {
-		return townOptions.get(KonTownOption.GOLEM_OFFENSE);
+		return getTownOption(KonTownOption.GOLEM_OFFENSE);
 	}
 
 	/*

--- a/core/src/main/resources/town-options.yml
+++ b/core/src/main/resources/town-options.yml
@@ -1,0 +1,13 @@
+# Town Option Overrides
+# 
+# All towns and kingdom capitals have a set of options which affect how each town works.
+# By default, the town lords can modify these options in-game.
+# Use this config file to force any town options to a fixed value for all towns, and prevent
+# players from modifying it in-game.
+# 
+#
+# Remember to use the "/k admin reload" command after modifying this file if the server is running.
+# 
+# /!\ DO NOT MODIFY VERSION /!\
+version: 0.0.0
+town-options:

--- a/core/src/main/resources/town-options.yml
+++ b/core/src/main/resources/town-options.yml
@@ -2,12 +2,40 @@
 # 
 # All towns and kingdom capitals have a set of options which affect how each town works.
 # By default, the town lords can modify these options in-game.
-# Use this config file to force any town options to a fixed value for all towns, and prevent
-# players from modifying it in-game.
-# 
+# Use this config file to force any town options to a fixed value, and prevent
+# players from modifying the options in-game.
+#
+# The town options are
+#   open                All kingdom members can build and use chests
+#   allied_building     Allied players can build
+#   plots_only          Residents can only build and use chests in plots
+#   friendly_redstone   Kingdom members can use redstone switches and doors
+#   enemy_redstone      Enemies can use redstone switches and doors
+#   golem_offense       Iron Golems will attack all enemies who enter
+#
+# Set options in the "global" section, or make a section for a specific town or kingdom capital.
+# Use the kingdom's name for its capital, or a town's name to override options (case sensitive).
+# Use the "global" section to override options for all towns and capitals in the server.
+#
+# Example settings
+# town-options:
+#   global:
+#     enemy_redstone: true
+#   RomeKingdom:
+#     open: true
+#   BigTown:
+#     plots_only: true
+#     golem_offense: false
 #
 # Remember to use the "/k admin reload" command after modifying this file if the server is running.
 # 
 # /!\ DO NOT MODIFY VERSION /!\
 version: 0.0.0
 town-options:
+#  global:
+#    enemy_redstone: true
+#  example_town_name:
+#    allied_building: true
+#    golem_offense: false
+#  example_kingdom_name:
+#    open: true

--- a/core/src/main/resources/town-options.yml
+++ b/core/src/main/resources/town-options.yml
@@ -6,12 +6,12 @@
 # players from modifying the options in-game.
 #
 # The town options are
-#   open                All kingdom members can build and use chests
-#   allied_building     Allied players can build
-#   plots_only          Residents can only build and use chests in plots
-#   friendly_redstone   Kingdom members can use redstone switches and doors
-#   enemy_redstone      Enemies can use redstone switches and doors
-#   golem_offense       Iron Golems will attack all enemies who enter
+#   OPEN                All kingdom members can build and use chests
+#   ALLIED_BUILDING     Allied players can build
+#   PLOTS_ONLY          Residents can only build and use chests in plots
+#   FRIENDLY_REDSTONE   Kingdom members can use redstone switches and doors
+#   ENEMY_REDSTONE      Enemies can use redstone switches and doors
+#   GOLEM_OFFENSE       Iron Golems will attack all enemies who enter
 #
 # Set options in the "global" section, or make a section for a specific town or kingdom capital.
 # Use the kingdom's name for its capital, or a town's name to override options (case sensitive).
@@ -20,12 +20,12 @@
 # Example settings
 # town-options:
 #   global:
-#     enemy_redstone: true
+#     ENEMY_REDSTONE: true
 #   RomeKingdom:
-#     open: true
+#     OPEN: true
 #   BigTown:
-#     plots_only: true
-#     golem_offense: false
+#     PLOTS_ONLY: true
+#     GOLEM_OFFENSE: false
 #
 # Remember to use the "/k admin reload" command after modifying this file if the server is running.
 # 
@@ -33,9 +33,10 @@
 version: 0.0.0
 town-options:
 #  global:
-#    enemy_redstone: true
+#    ENEMY_REDSTONE: true
 #  example_town_name:
-#    allied_building: true
-#    golem_offense: false
+#    ALLIED_BUILDING: true
+#    GOLEM_OFFENSE: false
 #  example_kingdom_name:
-#    open: true
+#    OPEN: true
+#    ENEMY_REDSTONE: false


### PR DESCRIPTION
# Konquest Pull Request

Closes #245

## Summary
Adds a new config file for overriding town options in towns and capitals.

## Change Details
* Adds new config file `town-options.yml`.
  * Set town options globally or per-town and per-capital.
  * Global overrides apply to all towns and capitals.
  * Town or capital overrides apply only to those towns/capitals, and ignore any global overrides.
* Town Options that are overridden cannot be changed by players or admins in-game, and they do not appear in the town management GUI menu.

## Checklist
- [x] I have merged the latest `develop` commit into this branch and resolved any conflicts.
- [x] I have tested this branch and it is working as intended.
- [x] This Pull Request is ready for review and merging.